### PR TITLE
4cc automation script adjustments

### DIFF
--- a/4CC_Automation/4CCAutomationScript.py
+++ b/4CC_Automation/4CCAutomationScript.py
@@ -1,9 +1,7 @@
-import csv, re, os
+import csv, re, os, sys
 from datetime import datetime
 
 def check4CCs(codecFile, newFileName, userSpec):
-    print("-----------------------------------------------------------")
-
     # Find 4CCs in Codec File----------------------------------------------------------
     with open(codecFile, 'r') as file:
         codesStripped = []
@@ -37,7 +35,7 @@ def check4CCs(codecFile, newFileName, userSpec):
 
         fileCodes = sorted(set(codesStripped))
 
-    # Find Identifiers CSV Files----------------------------------------------------------
+    # Find 4ccs in the repo CSV Files----------------------------------------------------------
     csvCodes = []
     codesInCSV = []
     for fileName in os.listdir(CSVFileDirectory):
@@ -48,7 +46,7 @@ def check4CCs(codecFile, newFileName, userSpec):
                 if 'code' in headers:
                     for row in csvReader:
                         csvCode = row['code']
-                        csvFile = fileName.lower()
+                        csvFile = fileName
                         csvLine = str(list(row.values()))
                         if 'specification' in headers:
                             csvSpec = row['specification'].lower()
@@ -157,29 +155,28 @@ def check4CCs(codecFile, newFileName, userSpec):
                 csvWriter.writerow([i[0], i[1], "", "", "", i[2]])
 
     # Test-------------------------------------------------------------------------------
-    missingCodes = set(fileCodes) - set(csvCodes)
-    print("Codes in file: %d" % len(codesStripped))
-    print("Sentences in file: %d" % len(sentenceList))
-    print("Unique codes in file: %d" % len(fileCodes))
-    print("Curly quotes: %d" % len(curlySpecs))
-    print("In CSV files: %d" % len(codesInCSV))
-    print("Missing: %d" % len(missingCodes))
-
-    print("-----------------------------------------------------------")
+    # missingCodes = set(fileCodes) - set(csvCodes)
+    # print("Codes in file: %d" % len(codesStripped))
+    # print("Sentences in file: %d" % len(sentenceList))
+    # print("Unique codes in file: %d" % len(fileCodes))
+    # print("Curly quotes: %d" % len(curlySpecs))
+    # print("In CSV files: %d" % len(codesInCSV))
+    # print("Missing: %d" % len(missingCodes))
+    #
+    # print("-----------------------------------------------------------")
     return
 # End check4CCs Function----------------------------------------------------------
 
 
 CodecFileDirectory = "specs/"
 CSVFileDirectory = "../CSV/"
-outputDirectory = "output/" + datetime.now().strftime("%Y-%m-%d_%H-%M-%S/")
+outputDirectory = "output/" + datetime.now().strftime("%Y%m%d%H%M%S/")
 os.mkdir(outputDirectory)
 
 # Start Loop to check the entire CodecFileDirectory------------------------------------------
 # for fileName1 in os.listdir(CodecFileDirectory):
 #     if fileName1.endswith(".txt"):
 #         codecFile = CodecFileDirectory+fileName1
-#         newFileName = outputDirectory + fileName1.strip(".txt") + "-missing.csv"
 #         while True:
 #             print(fileName1)
 #             userSpec = input("Please enter the shortname of the specification: ")
@@ -188,14 +185,27 @@ os.mkdir(outputDirectory)
 #                 print("You didn't type anything.")
 #             else:
 #                 break
+#         newFileName = outputDirectory + userSpec + "-check.csv"
 #         check4CCs(codecFile, newFileName, userSpec)
 # End Loop to check the entire CodecFileDirectory------------------------------------------
 
-
 # Comment out the above loop and use this code to run only one specification from the specs/ folder at a time:
+scriptname = ""
+specification_to_test = ""
+userSpec = ""
 
-specification_to_test = input('Please enter the filename of the specification to test (must be located in "4CC_Automation/specs/"): ')
-codecFile = CodecFileDirectory + specification_to_test
-newFileName = outputDirectory + specification_to_test.strip(".txt") + "-missing.csv"
-userSpec = input("Please enter the shortname of the specification: ")
-check4CCs(codecFile, newFileName, userSpec)
+for arg in sys.argv:
+    if arg.endswith(".py"):
+        scriptname = arg
+    elif arg.endswith(".txt"):
+        specification_to_test = arg
+    else:
+        userSpec = arg.lower()
+
+if scriptname == "" or specification_to_test == "" or userSpec == "":
+    print('You need to type "python(3) 4CCAutomationScript.py [specification filename] [specification shortname]"')
+else:
+    codecFile = CodecFileDirectory + specification_to_test
+    newFileName = outputDirectory + userSpec + "-check.csv"
+    print("Running %s on %s with shortname %s > %s" % (scriptname, specification_to_test, userSpec, newFileName))
+    check4CCs(codecFile, newFileName, userSpec)

--- a/4CC_Automation/4CCAutomationScript.py
+++ b/4CC_Automation/4CCAutomationScript.py
@@ -167,13 +167,11 @@ def check4CCs(codecFile, newFileName, userSpec):
     return
 # End check4CCs Function----------------------------------------------------------
 
-
-CodecFileDirectory = "specs/"
-CSVFileDirectory = "../CSV/"
-outputDirectory = "output/" + datetime.now().strftime("%Y%m%d%H%M%S/")
-os.mkdir(outputDirectory)
-
 # Start Loop to check the entire CodecFileDirectory------------------------------------------
+# CodecFileDirectory = "specs/"
+# CSVFileDirectory = "../CSV/"
+# outputDirectory = "output/" + datetime.now().strftime("%Y%m%d%H%M%S/")
+# os.mkdir(outputDirectory)
 # for fileName1 in os.listdir(CodecFileDirectory):
 #     if fileName1.endswith(".txt"):
 #         codecFile = CodecFileDirectory+fileName1
@@ -189,23 +187,29 @@ os.mkdir(outputDirectory)
 #         check4CCs(codecFile, newFileName, userSpec)
 # End Loop to check the entire CodecFileDirectory------------------------------------------
 
-# Comment out the above loop and use this code to run only one specification from the specs/ folder at a time:
-scriptname = ""
-specification_to_test = ""
-userSpec = ""
+# Runs only one specification from the specs/ folder at a time using arguments from the command line:
+CSVFileDirectory = "../CSV/"
+warning = 'You need to type "python(3) 4CCAutomationScript.py [path/to/specificationFilename] [specification shortname] [*optional* path/to/outputFilename]"'
 
-for arg in sys.argv:
-    if arg.endswith(".py"):
-        scriptname = arg
-    elif arg.endswith(".txt"):
-        specification_to_test = arg
-    else:
-        userSpec = arg.lower()
+if len(sys.argv) < 3:
+    print("You didn't provide enough arguments.")
+    print(warning)
+elif len(sys.argv) == 3:
+    scriptname = sys.argv[0]
+    codecFile = sys.argv[1]
+    userSpec = sys.argv[2]
+    newFileName = userSpec + "-check.csv"
 
-if scriptname == "" or specification_to_test == "" or userSpec == "":
-    print('You need to type "python(3) 4CCAutomationScript.py [specification filename] [specification shortname]"')
-else:
-    codecFile = CodecFileDirectory + specification_to_test
-    newFileName = outputDirectory + userSpec + "-check.csv"
-    print("Running %s on %s with shortname %s > %s" % (scriptname, specification_to_test, userSpec, newFileName))
+    print("Running %s on %s with shortname %s > %s" % (scriptname, codecFile, userSpec, newFileName))
     check4CCs(codecFile, newFileName, userSpec)
+elif len(sys.argv) == 4:
+    scriptname = sys.argv[0]
+    codecFile = sys.argv[1]
+    userSpec = sys.argv[2]
+    newFileName = sys.argv[3]
+
+    print("Running %s on %s with shortname %s > %s" % (scriptname, codecFile, userSpec, newFileName))
+    check4CCs(codecFile, newFileName, userSpec)
+elif len(sys.argv) > 4:
+    print("You provided too many arguments.")
+    print(warning)

--- a/4CC_Automation/4CCAutomationScript.py
+++ b/4CC_Automation/4CCAutomationScript.py
@@ -176,29 +176,26 @@ outputDirectory = "output/" + datetime.now().strftime("%Y-%m-%d_%H-%M-%S/")
 os.mkdir(outputDirectory)
 
 # Start Loop to check the entire CodecFileDirectory------------------------------------------
-for fileName1 in os.listdir(CodecFileDirectory):
-    if fileName1.startswith(("~",".")):
-        print("%s is not an acceptable file format: " % fileName1)
-    elif fileName1.endswith(".txt"):
-        codecFile = CodecFileDirectory+fileName1
-        newFileName = outputDirectory + fileName1.strip(".txt") + "-missing.csv"
-        while True:
-            print(fileName1)
-            userSpec = input("Please enter a specification: ")
-            userSpec = userSpec.lower()
-            if userSpec == "":
-                print("You didn't type anything.")
-            else:
-                break
-        check4CCs(codecFile, newFileName, userSpec)
+# for fileName1 in os.listdir(CodecFileDirectory):
+#     if fileName1.endswith(".txt"):
+#         codecFile = CodecFileDirectory+fileName1
+#         newFileName = outputDirectory + fileName1.strip(".txt") + "-missing.csv"
+#         while True:
+#             print(fileName1)
+#             userSpec = input("Please enter the shortname of the specification: ")
+#             userSpec = userSpec.lower()
+#             if userSpec == "":
+#                 print("You didn't type anything.")
+#             else:
+#                 break
+#         check4CCs(codecFile, newFileName, userSpec)
 # End Loop to check the entire CodecFileDirectory------------------------------------------
 
 
 # Comment out the above loop and use this code to run only one specification from the specs/ folder at a time:
-# specification_to_test = "ISO-IEC_FDIS_14496-12-2018.txt"
-#
-# codecFile = CodecFileDirectory + specification_to_test
-# newFileName = outputDirectory + specification_to_test.strip(".txt") + "-missing.csv"
-# print(specification_to_test)
-# userSpec = input("Please enter a specification: ")
-# check4CCs(codecFile, newFileName, userSpec)
+
+specification_to_test = input('Please enter the filename of the specification to test (must be located in "4CC_Automation/specs/"): ')
+codecFile = CodecFileDirectory + specification_to_test
+newFileName = outputDirectory + specification_to_test.strip(".txt") + "-missing.csv"
+userSpec = input("Please enter the shortname of the specification: ")
+check4CCs(codecFile, newFileName, userSpec)

--- a/4CC_Automation/README.md
+++ b/4CC_Automation/README.md
@@ -14,9 +14,9 @@ We created two new MP4RA CSV files: CSV/unlisted.csv and CSV/textualcontent.csv.
 ## How to Run
 To run this script on your own specifications type in terminal:
 ```
-python(3) 4CCAutomationScript.py [path/to/specificationFilename] [specification shortname] [*optional* path/to/outputFilename]"'
+python3 4CCAutomationScript.py [path/to/specificationFilename] [specification shortname] [*optional* path/to/outputFilename]"'
 ```
-*All paths are relative to "MP4RArepo/4CC_Automation/4CCAutomationScript.py"*
+*All paths are relative to the script: "MP4RArepo/4CC_Automation/4CCAutomationScript.py"*
 
 1. [path/to/specificationFilename] = specification file, exported from Microsoft Word as a text file, encoded as unicode (UTF-8).
 2. [specification shortname] = the short code of that specification (as listed at mp4ra.org). For example:

--- a/4CC_Automation/README.md
+++ b/4CC_Automation/README.md
@@ -4,7 +4,7 @@ First uploaded to Github: 5/30/2019
 Last updated: 5/30/2019  
 
 ## Description
-The 4CCAutomationScript.py was created to automate finding unregistered or mistakenly registered specifications on the MP4RA website. The script takes a folder of specification files (4CC_Automation/specs/text/) and the folder of CSV files from the MP4RA (CSV/), finds all the four character codes (4CCs) in each, and compares what is in the specification files to what is registered in the MP4RA.
+The 4CCAutomationScript.py was created to automate finding unregistered or mistakenly registered specifications on the MP4RA website. The script takes a folder of specification files (4CC_Automation/specs/) and the folder of CSV files from the MP4RA (CSV/), finds all the four character codes (4CCs) in each, and compares what is in the specification files to what is registered in the MP4RA.
 
 ## unlisted.csv and textualcontent.csv
 We created two new MP4RA CSV files: CSV/unlisted.csv and CSV/textualcontent.csv.
@@ -25,16 +25,16 @@ The script outputs a CSV file (into 4CC_Automation/output/) for each specificati
 
 ## How to Run
 To run this script on your own specifications:
-- Export your specifications from Microsoft Word to the "specs" folder as text files, encoded as unicode (UTF-8).
+- Export your specifications from Microsoft Word to "4CC_Automation/specs/" folder as text files, encoded as unicode (UTF-8).
 - Run "MP4RA-Automate.py” in the terminal
-- For each spec in the “specs” folder, it will prompt you for the short code of that specification (as listed at mp4ra.org). For example:
+- For each spec in "/specs/" folder, it will prompt you for the short code of that specification (as listed at mp4ra.org). For example:
 ```
 $ Python3 4CCsAutomationScript.py
 -
-heif-w18310_23008-12_Ed2_FDIS+COR1_R1.txt
+w18310_23008-12_Ed2_FDIS+COR1_R1.txt
 Please enter a specification: heif
 -
-miaf-wXXXXX-FDIS-MIAF-RB-3.txt
+wXXXXX-FDIS-MIAF-RB-3.txt
 Please enter a specification: miaf
 ```
 - Note: You can also comment-out a loop at the bottom of the script and un-comment the code below it to test one specification at a time.

--- a/4CC_Automation/README.md
+++ b/4CC_Automation/README.md
@@ -4,38 +4,42 @@ First uploaded to Github: 5/30/2019
 Last updated: 5/30/2019  
 
 ## Description
-The 4CCAutomationScript.py was created to automate finding unregistered or mistakenly registered specifications on the MP4RA website. The script takes a folder of specification files (4CC_Automation/specs/) and the folder of CSV files from the MP4RA (CSV/), finds all the four character codes (4CCs) in each, and compares what is in the specification files to what is registered in the MP4RA.
+The 4CCAutomationScript.py was created to automate finding unregistered or mistakenly registered specifications on the MP4RA website. The script takes a specification file, the folder of CSV files from the MP4RA (CSV/), finds all the four character codes (4CCs) in each, and compares what is in the specification file to what is registered in the MP4RA.
 
 ## unlisted.csv and textualcontent.csv
 We created two new MP4RA CSV files: CSV/unlisted.csv and CSV/textualcontent.csv.
 - unlisted.csv should store 4CCs that are purposely unlisted/unregistered. Meaning, we know they are missing from the MP4RA and they should stay that way, at least for now.
 - textualcontent.csv should store four character long strings that are mistakenly found by this script but are not 4CCs. This script finds any four character long strings that are between single quotes (The regex being used is: `[\'\‘\’][A-Za-z0-9 +-]{4}[\'\‘\’]`) so mistakes happen (i.e. " to ", "also", etc.).
 
+## How to Run
+To run this script on your own specifications type in terminal:
+```
+python(3) 4CCAutomationScript.py [path/to/specificationFilename] [specification shortname] [*optional* path/to/outputFilename]"'
+```
+*All paths are relative to "MP4RArepo/4CC_Automation/4CCAutomationScript.py"*
+
+1. [path/to/specificationFilename] = specification file, exported from Microsoft Word as a text file, encoded as unicode (UTF-8).
+2. [specification shortname] = the short code of that specification (as listed at mp4ra.org). For example:
+```
+$ Python3 4CCsAutomationScript.py w18310_23008-12_Ed2_FDIS+COR1_R1.txt heif
+```
+OR
+```
+$ Python3 4CCsAutomationScript.py wXXXXX-FDIS-MIAF-RB-3.txt miaf
+```
+3. [\*optional\* path/to/outputFilename] = the name of the csv file produced by this script. If you do not provide this argument, shortname + "-check.csv" will be used.
+```
+$ Python3 4CCsAutomationScript.py wXXXXX-FDIS-MIAF-RB-3.txt miaf newfile.csv
+```
+
 ## Output
-The script outputs a CSV file (into 4CC_Automation/output/) for each specification file that is in the specs/ folder with:
+The script outputs a CSV file with:
 
 1. Code-points that are in an RA CSV file and registered to this spec. (good)
 2. Code-points that are in an RA CSV file and registered to a different spec. (probably a citation)
 3. Code-points that are in a special CSV file (unlisted.csv), listed as for this spec., that documents deliberately unregistered 4CCs (so they don’t repeatedly show up as 'missing')
 4. 4-character patterns that are actually not 4CCs at all, that are in a special CSV file (textualcontent.csv), listed as for this spec., that documents text that looks like a 4CC but is not (e.g. like ’this’).
-5. Code-points that seem to be unregistered/missing\*
-6. 4CCs that use curly quotes, not straight ones, and are not in the textualcontent.csv file listed against this spec.\*  
+5. \*Code-points that seem to be unregistered/missing
+6. \*4CCs that use curly quotes, not straight ones, and are not in the textualcontent.csv file listed against this spec.
 
 \* Ideally, there is nothing in section 5 or 6. If there is, it should be easy to take these rows, and make pull requests as needed against the CSV files to register the codes reported in (5). To fix (6), either list them as textual content, or if they are 4CCs in curly quotes, fix the text.
-
-## How to Run
-To run this script on your own specifications:
-- Export your specifications from Microsoft Word to "4CC_Automation/specs/" folder as text files, encoded as unicode (UTF-8).
-- Run "MP4RA-Automate.py” in the terminal
-- For each spec in "/specs/" folder, it will prompt you for the short code of that specification (as listed at mp4ra.org). For example:
-```
-$ Python3 4CCsAutomationScript.py
--
-w18310_23008-12_Ed2_FDIS+COR1_R1.txt
-Please enter a specification: heif
--
-wXXXXX-FDIS-MIAF-RB-3.txt
-Please enter a specification: miaf
-```
-- Note: You can also comment-out a loop at the bottom of the script and un-comment the code below it to test one specification at a time.
-- The resulting csv files will be saved in “results/[Date]/”


### PR DESCRIPTION
We decided to remove the loop that checks a folder of specifications against the CSV files and instead checks one specification at a time. I also made it work right from the command line so you can type in the arguments there without having to adjust the script. See the readme file for additional details.

This makes it much easier to use and should be easier to implement into other scripts, if needed.