### PR TITLE
Updating the regex in both scripts to find the correct unicode characters in 4CCs

### DIFF
--- a/4CC_Automation/4CCAutomationScript.py
+++ b/4CC_Automation/4CCAutomationScript.py
@@ -12,11 +12,11 @@ def check4CCs(codecFile, newFileName, userSpec):
         f = file.readlines()
 
         for line in f:
-            #stip spaces/tabs and hyphens out of lines.
-            strippedLine = re.sub('\s+\-', ' ', line)
+            #convert multiple spaces/tabs/etc into single spaces to print better in the CSV file.
+            strippedLine = re.sub('\s+', ' ', line)
 
-            regex = "[\'\‘\’][A-Za-z0-9 +-]{4}[\'\‘\’]"
-            codesQuotes = re.findall(regex, strippedLine)
+            regex = "[\'\‘\’].{4}[\'\‘\’]"
+            codesQuotes = re.findall(regex, line)
             if codesQuotes:
                 for i in codesQuotes:
                     codeNoSpaces = i.replace(' ', '$20')
@@ -24,8 +24,8 @@ def check4CCs(codecFile, newFileName, userSpec):
                     codesStripped.append(codeNoQuotes)
                     sentenceList.append(codeNoQuotes + " - " + strippedLine)
 
-            regexCurly = "[\‘\’][A-Za-z0-9 +-]{4}[\‘\’]"
-            codesBad = re.findall(regexCurly, strippedLine)
+            regexCurly = "[\‘\’].{4}[\‘\’]"
+            codesBad = re.findall(regexCurly, line)
             if codesBad:
                 for i in codesBad:
                     codeBadNoSpaces = i.replace(' ', '$20')

--- a/scripts/PRsanitycheck.py
+++ b/scripts/PRsanitycheck.py
@@ -48,7 +48,7 @@ def getCSV4CCs(directory):
 
 #Check to ensure all 4ccs are actually four characters matching the regex below
 def notfourcharacters(codes, exceptions=[]):
-    pattern = re.compile("^[A-Za-z0-9 +-]{4}$")
+    pattern = re.compile(u'^[\u0020-\u007E]{4}$', re.UNICODE)
     mistakeCodes = []
     for code in codes:
         if pattern.match(code[0]) == None:
@@ -61,7 +61,7 @@ def notfourcharacters(codes, exceptions=[]):
     elif mistakeCodes != []:
         for i in mistakeCodes:
             print("\t'%s' from '%s'" % (i[0], i[1]))
-        print("\tAll 4ccs are not four characters - FAIL")
+        print("\tAll 4ccs are either longer than four characters or not valid - FAIL")
         return 1
 
 #Finds duplitcated codes. Only fails the check if the duplicates are in the same CSV File


### PR DESCRIPTION
4CCAuto Script: using the [\'\‘\’].{4}[\'\‘\’] regex to find any 4 characters between quotes. Previously, my regex was a bit too narrow and would have excluded valid characters for 4CCs.

PRSanity Check: using the ^[\u0020-\u007E]{4}$ regex when checking for valid 4CCs using the unicode range that is acceptable.