### PR TITLE
Add 'fiel' box

### DIFF
--- a/CSV/sample-entries-boxes.csv
+++ b/CSV/sample-entries-boxes.csv
@@ -20,6 +20,7 @@ dvcC,Dolby Vision Configuration,Video,Dolby Vision
 dvvC,Dolby Vision Extended Configuration,Video,Dolby Vision
 ecam,Extrinsic camera parameters,Video,NALu Video
 esds,Elementary stream descriptor,General,MP4v2
+fiel,Field Coding,Video,MJ2 
 hvcC,HEVC Configuration,Video,NALu Video
 hvtC,HEVC Tile Configuration,Video,NALu Video
 icam,Intrinsic camera parameters,Video,NALu Video

--- a/CSV/sample-entries-boxes.csv
+++ b/CSV/sample-entries-boxes.csv
@@ -20,7 +20,7 @@ dvcC,Dolby Vision Configuration,Video,Dolby Vision
 dvvC,Dolby Vision Extended Configuration,Video,Dolby Vision
 ecam,Extrinsic camera parameters,Video,NALu Video
 esds,Elementary stream descriptor,General,MP4v2
-fiel,Field Coding,Video,MJ2 
+fiel,Field Coding,Video,MJ2
 hvcC,HEVC Configuration,Video,NALu Video
 hvtC,HEVC Tile Configuration,Video,NALu Video
 icam,Intrinsic camera parameters,Video,NALu Video


### PR DESCRIPTION
The syntax of the `fiel` box is specified at 6.1.2 of ISO/IEC 15444-3:2006.

![Annotation 2019-12-31 135705](https://user-images.githubusercontent.com/4871350/71635004-7342af80-2bd5-11ea-9011-345da9dd0dc2.png)

_NOTEL: the definition is duplicated at M.4.3 of ISO/IEC 15444-1:2019.

![Annotation 2019-12-31 135751](https://user-images.githubusercontent.com/4871350/71635035-c74d9400-2bd5-11ea-9cdd-fc3881f64453.png)
