### PR TITLE
Add slh3 to brands

### DIFF
--- a/CSV/brands.csv
+++ b/CSV/brands.csv
@@ -185,6 +185,7 @@ senv,Video contents Sony Entertainment Network provides by using MP4 file format
 sims,Media Segment conforming to the Sub-Indexed Media Segment format type for ISO base media file format.,DASH
 sisx,Single Index Segment used to index MPEG-2 TS based Media Segments.,DASH
 slh1,Dynamic metadata for Single Layer SDR-compatible HDR video streams,SL-HDR
+slh2,Dynamic metadata for Single Layer PQ-based HDR video streams,SL-HDR
 slh3,Dynamic metadata for Single Layer HLG-based HDR video streams,SL-HDR
 ssss,Subsegment Index Segment used to index MPEG-2 TS based Media Segments.,DASH
 uvvu,"UltraViolet file brand – conforming to the DECE Common File Format spec, Annex E.",DECE

--- a/CSV/brands.csv
+++ b/CSV/brands.csv
@@ -185,8 +185,6 @@ senv,Video contents Sony Entertainment Network provides by using MP4 file format
 sims,Media Segment conforming to the Sub-Indexed Media Segment format type for ISO base media file format.,DASH
 sisx,Single Index Segment used to index MPEG-2 TS based Media Segments.,DASH
 slh1,Dynamic metadata for Single Layer SDR-compatible HDR video streams,SL-HDR
-slh2,Dynamic metadata for Single Layer PQ-based HDR video streams,SL-HDR
-slh3,Dynamic metadata for Single Layer HLG-based HDR video streams,SL-HDR
 ssss,Subsegment Index Segment used to index MPEG-2 TS based Media Segments.,DASH
 uvvu,"UltraViolet file brand – conforming to the DECE Common File Format spec, Annex E.",DECE
 XAVC,XAVC File Format,Sony

--- a/CSV/brands.csv
+++ b/CSV/brands.csv
@@ -184,6 +184,7 @@ SEBK,Home and Mobile Multimedia Platform (HMMP),Sony
 senv,Video contents Sony Entertainment Network provides by using MP4 file format,Sony
 sims,Media Segment conforming to the Sub-Indexed Media Segment format type for ISO base media file format.,DASH
 sisx,Single Index Segment used to index MPEG-2 TS based Media Segments.,DASH
+slh1,Dynamic Metadata for single layer SDR-compatible HDR video streams,SL-HDR
 ssss,Subsegment Index Segment used to index MPEG-2 TS based Media Segments.,DASH
 uvvu,"UltraViolet file brand – conforming to the DECE Common File Format spec, Annex E.",DECE
 XAVC,XAVC File Format,Sony

--- a/CSV/brands.csv
+++ b/CSV/brands.csv
@@ -185,7 +185,8 @@ senv,Video contents Sony Entertainment Network provides by using MP4 file format
 sims,Media Segment conforming to the Sub-Indexed Media Segment format type for ISO base media file format.,DASH
 sisx,Single Index Segment used to index MPEG-2 TS based Media Segments.,DASH
 slh1,Dynamic metadata for Single Layer SDR-compatible HDR video streams,SL-HDR
-slh2,Dynamic metadata for Single Layer PQ-based HDR video streams,SL-HDR 
+slh2,Dynamic metadata for Single Layer PQ-based HDR video streams,SL-HDR
+slh3,Dynamic metadata for Single Layer HLG-based HDR video streams,SL-HDR
 ssss,Subsegment Index Segment used to index MPEG-2 TS based Media Segments.,DASH
 uvvu,"UltraViolet file brand – conforming to the DECE Common File Format spec, Annex E.",DECE
 XAVC,XAVC File Format,Sony

--- a/CSV/brands.csv
+++ b/CSV/brands.csv
@@ -185,6 +185,7 @@ senv,Video contents Sony Entertainment Network provides by using MP4 file format
 sims,Media Segment conforming to the Sub-Indexed Media Segment format type for ISO base media file format.,DASH
 sisx,Single Index Segment used to index MPEG-2 TS based Media Segments.,DASH
 slh1,Dynamic metadata for Single Layer SDR-compatible HDR video streams,SL-HDR
+slh3,Dynamic metadata for Single Layer HLG-based HDR video streams,SL-HDR
 ssss,Subsegment Index Segment used to index MPEG-2 TS based Media Segments.,DASH
 uvvu,"UltraViolet file brand – conforming to the DECE Common File Format spec, Annex E.",DECE
 XAVC,XAVC File Format,Sony

--- a/CSV/brands.csv
+++ b/CSV/brands.csv
@@ -184,7 +184,7 @@ SEBK,Home and Mobile Multimedia Platform (HMMP),Sony
 senv,Video contents Sony Entertainment Network provides by using MP4 file format,Sony
 sims,Media Segment conforming to the Sub-Indexed Media Segment format type for ISO base media file format.,DASH
 sisx,Single Index Segment used to index MPEG-2 TS based Media Segments.,DASH
-slh1,Dynamic Metadata for single layer SDR-compatible HDR video streams,SL-HDR
+slh1,Dynamic metadata for Single Layer SDR-compatible HDR video streams,SL-HDR
 ssss,Subsegment Index Segment used to index MPEG-2 TS based Media Segments.,DASH
 uvvu,"UltraViolet file brand – conforming to the DECE Common File Format spec, Annex E.",DECE
 XAVC,XAVC File Format,Sony

--- a/CSV/specifications.csv
+++ b/CSV/specifications.csv
@@ -86,6 +86,7 @@ RealHD,RealHD,<a href='http://www.realnetworks.com/realmediahd'>RealMedia™ HD<
 ross,Ross,<a href='http://www.rossvideo.com/'>Ross Video</a>
 samsung,Samsung,"<a href='http://www.samsung.com/'>Samsung</a> "
 SDV,SDV,"<a href='http://www.sdcard.org/'>The SD Card Association</a>: SD Memory Card Specifications, Part 8, VIDEO SPECIFICATIONS"
+SL-HDR,SL-HDR,"<a href='http://www.etsi.org/'>ETSI</a> TS 103 433 - High-Performance Single Layer High Dynamic Range System"
 smptevc1,SMPTE,"<a href='http://www.smpte.org/'>SMPTE</a> RP2025:2007, VC-1 Bitstream Storage in the ISO Base Media File Format"
 Sony,Sony,<a href='http://www.sony.net'>Sony Corporation</a>
 UMG,Universal Music Group,Specification is made available only under license; contact <a href='mailto:uits-%20legal@umusic.com'>Universal Music Group</a>.


### PR DESCRIPTION
'slh3' is defined in Annex H of ETSI TS 103 433-1, which is Part 1 of the SL-HDR specifications.
It indicates the presence of SL-HDR3 metadata, for which the processing is specified in Part 3 (TS 103 433-3).
(This request includes the changes for adding slh1.)