### PR TITLE
Update migrated 4cc's and add missing track reference types from ISOBMFF

### DIFF
--- a/CSV/boxes.csv
+++ b/CSV/boxes.csv
@@ -50,7 +50,7 @@ frpa,Front Part,ISO-Partial
 ftyp,file type and compatibility,ISO
 gitn,Group ID to name,ISO
 grpi,OMA DRM Group ID,OMA DRM 2.0
-grpl,Groups List box,HEIF
+grpl,Groups list box,ISO
 hdlr,"handler, declares the media (handler) type",ISO
 hmhd,"hint media header, overall information (hint track only)",ISO
 hpix,Hipix Rich Picture (user-data or meta-data),Hipix

--- a/CSV/entity-groups.csv
+++ b/CSV/entity-groups.csv
@@ -1,4 +1,4 @@
 code,description,specification
-altr,alternative entity grouping,HEIF
+altr,alternative entity grouping,ISO
 eqiv,equivalent entity grouping,HEIF
 ster,Stereo entity grouping,HEIF

--- a/CSV/sample-groups.csv
+++ b/CSV/sample-groups.csv
@@ -30,7 +30,7 @@ seig,Sample Encryption Information,sample group,ISO Common Encryption
 scif,SVC Scalability Information,sample group,NALu Video
 scnm,AVC/SVC/MVC map groups,sample group,NALu Video
 stsa,Step-wise Temporal Layer,sample group,NALu Video
-stmi,SampleToMetadataItemEntry,sample group,HEIF
+stmi,SampleToMetadataItemEntry,sample group,ISO
 svdr,SVC dependency range,sample group,NALu Video
 svip,Initial parameter sets box for tiers, sample group,NALu Video
 svpr,Priority range,sample group,NALu Video

--- a/CSV/track-references.csv
+++ b/CSV/track-references.csv
@@ -1,7 +1,7 @@
 code,description,specification
 adda,Additional audio track,DRC
 adrc,DRC metadata track,DRC
-auxl,Auxiliary track reference,HEIF
+auxl,Auxiliary track reference,ISO
 avcp,AVC parameter set stream link,NALu Video
 cdsc,this track describes the referenced track.,MPEG-4
 deps,track containing the depth view,NALu Video
@@ -20,7 +20,7 @@ swfr,AVC Switch from,NALu Video
 swto,AVC Switch to,NALu Video
 sync,this track uses the referenced track as its synchronization source.,MPEG-4
 tbas,HEVC Tile track base,NALu Video
-thmb,Thumbnail track,HEIF
+thmb,Thumbnail track reference,ISO
 tmcd,Time code. Usually references a time code track.,Apple
 vdep,Auxiliary video depth,ISO
 vplx,Auxiliary video parallax,ISO

--- a/CSV/track-references.csv
+++ b/CSV/track-references.csv
@@ -24,3 +24,5 @@ thmb,Thumbnail track reference,ISO
 tmcd,Time code. Usually references a time code track.,Apple
 vdep,Auxiliary video depth,ISO
 vplx,Auxiliary video parallax,ISO
+font,this track uses fonts carried/defined in the referenced track,ISO
+subt,subtitle or timed text or overlay graphical information,ISO


### PR DESCRIPTION
This PR introduces the following changes:

1. Move `grpl`, `altr`, `stmi`, `auxl`, `thmb` from HEIF to ISO  (now defined in ISOBMFF spec.)

2. Adding `font` and `subt` track reference types as defined in section 8.3.3 of ISOBMFF 