### PR TITLE
WebVTTSourceLabelBox and minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 *~
-
 *swp
-
 node_modules
-
 dist/js
+.DS_Store

--- a/CSV/boxes.csv
+++ b/CSV/boxes.csv
@@ -247,4 +247,4 @@ xml$20,a tool by which vendors can add XML formatted information,JPEG2000
 !mov,Compressed movie,ISO
 !six,Compressed segment index,ISO
 !ssx,Compressed subsegment index,ISO
-
+vlab,WebVTT Source Label,ISO-Text

--- a/CSV/boxes.csv
+++ b/CSV/boxes.csv
@@ -247,4 +247,3 @@ xml$20,a tool by which vendors can add XML formatted information,JPEG2000
 !mov,Compressed movie,ISO
 !six,Compressed segment index,ISO
 !ssx,Compressed subsegment index,ISO
-vlab,WebVTT Source Label,ISO-Text

--- a/CSV/sample-entries-boxes.csv
+++ b/CSV/sample-entries-boxes.csv
@@ -58,3 +58,4 @@ vpcC,VP9 Codec Configuration,Video,VPxx
 vsib,View scalability information,Video,NALu Video
 vttC,WebVTTConfigurationBox,Text,ISO-Text
 vwid,View identifier,Video,NALu Video
+vlab,WebVTT Source Label,Text,ISO-Text

--- a/CSV/specifications.csv
+++ b/CSV/specifications.csv
@@ -71,7 +71,6 @@ MPEGHAudio,MPEG-H,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 2300
 MPEG-VSAF,MPEG-VSAF,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23000-10 Video surveillance application format"
 MMT,MMT,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23008-1 MPEG Media Transport
 matrox,Matrox,<a href='http://www.matrox.com/'>Matrox</a>
-Metrics,Metrics,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23001-10 Carriage of timed metadata metrics of media in ISO base media file format
 AVC,NALu Video,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 14496-15, Carriage of NAL unit structured video in the ISO Base Media File Format"
 nikon,Nikon,<a href='http://www.nikon.com/'>Nikon</a>
 OMADCF,OMA DRM 2.0,"OMA DRM; <a href='http://www.openmobilealliance.org/'>Open Mobile Alliance </a>Digital Rights Management, DRM Content Format 2.0 (OMA-TS-DRM_DCF-V2_0_1-20080226-A)"

--- a/CSV/textualcontent.csv
+++ b/CSV/textualcontent.csv
@@ -26,3 +26,4 @@ VXYZ,four character code of the manufacturer of the codec e.g. 'VXYZ',3GPP
 subs,sub-sample index “j” in the ‘subs’,ISO-Text
 size,The ’size’ field of the container box ScalabilityInformationSEIBox,NALu Video
 ttml,used in the codecs parameter,ISO-Text
+.mp4,The preferred file extension is ‘.mp4’,MP4v2

--- a/CSV/unlisted.csv
+++ b/CSV/unlisted.csv
@@ -59,3 +59,5 @@ vtta,VTTAdditionalTextBox only present in WebVTT sample payload,ISO-Text
 vttc,VTTCueBox only present in WebVTT sample payload,ISO-Text
 vtte,VTTEmptyCueBox only present in WebVTT sample payload,ISO-Text
 ?vc?,Pattern for sample-entry codes,NALu Video
+abcd,4CC example,ISO
+main,a main video track for the wide angle view,Metrics


### PR DESCRIPTION
- Add vlab box (which is located in the WVTTSampleEntry)
- Add a few values which should be ignored by the scripts
- Remove a duplicate entry for ~Timed text~ Metrics spec