### PR TITLE
remove evmC as it is the same as evcC

### DIFF
--- a/CSV/sample-entries-boxes.csv
+++ b/CSV/sample-entries-boxes.csv
@@ -23,7 +23,6 @@ dvvC,Dolby Vision Extended Configuration,Video,Dolby Vision
 ecam,Extrinsic camera parameters,Video,NALu Video
 esds,Elementary stream descriptor,General,MP4v2
 evcC,EVC configuration,Video,NALu Video
-evmC,Configuration for EVC slice base track,Video,NALu Video
 evsC,Configuration for EVC slice component track,Video,NALu Video
 fiel,Field Coding,Video,MJ2
 hvcC,HEVC Configuration,Video,NALu Video


### PR DESCRIPTION
The content of the Box `evmC` is exactly the same as in `evcC`. 