### PR TITLE
Corrections

### DIFF
--- a/CSV/boxes.csv
+++ b/CSV/boxes.csv
@@ -255,3 +255,4 @@ svip,Initial parameter sets box for tiers,NALu Video
 svpr,Priority range,NALu Video
 tran,SVC lightweight transcoding,NALu Video
 vipr,View priority Box,NALu Video
+sdp$20,SDP information,ISO

--- a/CSV/boxes.csv
+++ b/CSV/boxes.csv
@@ -256,3 +256,4 @@ svpr,Priority range,NALu Video
 tran,SVC lightweight transcoding,NALu Video
 vipr,View priority Box,NALu Video
 sdp$20,SDP information,ISO
+stvi,Stereo Video Box,ISO

--- a/CSV/boxes.csv
+++ b/CSV/boxes.csv
@@ -254,3 +254,4 @@ svdr,SVC dependency range,NALu Video
 svip,Initial parameter sets box for tiers,NALu Video
 svpr,Priority range,NALu Video
 tran,SVC lightweight transcoding,NALu Video
+vipr,View priority Box,NALu Video

--- a/CSV/boxes.csv
+++ b/CSV/boxes.csv
@@ -73,12 +73,12 @@ imif,IPMP Information box,ISO
 infe,Item information entry,ISO
 infu,OMA DRM Info URL,OMA DRM 2.0
 iods,Object Descriptor container box,MP4v1
-ipco,ItemPropertyContainerBox,HEIF
+ipco,ItemPropertyContainerBox,ISO
 iphd,reserved for IPMP Stream header,MP4v1
-ipma,ItemPropertyAssociation,HEIF
+ipma,ItemPropertyAssociation,ISO
 ipmc,IPMP Control Box,ISO
 ipro,item protection,ISO
-iprp,Item Properties Box,HEIF
+iprp,Item Properties Box,ISO
 iref,Item reference,ISO
 j2kH,JPEG 2000 header info,J2KHEIF
 j2kP,JPEG 2000 prefix,J2KHEIF

--- a/CSV/boxes.csv
+++ b/CSV/boxes.csv
@@ -124,7 +124,7 @@ movd,mesh omnidirectional video,OMAF
 mstv,MVC sub track view box,NALu Video
 mvcg,Multiview group,NALu Video
 mvci,Multiview Information,NALu Video
-mvdr,MVDDepthResolutionBox,NALu Video
+3dpr,MVDDepthResolutionBox,NALu Video
 mvex,movie extends box,ISO
 mvhd,"movie header, overall declarations",ISO
 mvra,Multiview Relation Attribute,NALu Video

--- a/CSV/boxes.csv
+++ b/CSV/boxes.csv
@@ -247,3 +247,10 @@ xml$20,a tool by which vendors can add XML formatted information,JPEG2000
 !mov,Compressed movie,ISO
 !six,Compressed segment index,ISO
 !ssx,Compressed subsegment index,ISO
+iroi,SVC region of interest box,NALu Video
+ldep,Tier dependency box,NALu Video
+rrgn,SVC rect region box,NALu Video
+svdr,SVC dependency range,NALu Video
+svip,Initial parameter sets box for tiers,NALu Video
+svpr,Priority range,NALu Video
+tran,SVC lightweight transcoding,NALu Video

--- a/CSV/handlers.csv
+++ b/CSV/handlers.csv
@@ -45,3 +45,5 @@ tmcd,Timecode,handler,Apple
 twen,QuickTime Tween track handler,handler,Apple
 uri$20,URI identified metadata,handler,DVB
 vide,Video,handler,ISO
+hapt,Haptics,handler,ISO
+volv,Volumetric,handler,ISO

--- a/CSV/item-references.csv
+++ b/CSV/item-references.csv
@@ -8,5 +8,6 @@ fdel,File delivery reference,item ref.,ISO
 grid,Image item grid reference,item ref.,HEIF
 iloc,Item data location,item ref.,ISO
 prem,Pre-Multiplied item,item ref.,MIAF
+tbas,HEVC Tile track base item reference,item ref.,HEIF
 thmb,Thumbnail image item reference,item ref.,HEIF
 pred,Predictively coded item reference,item ref.,HEIF

--- a/CSV/sample-entries-boxes.csv
+++ b/CSV/sample-entries-boxes.csv
@@ -54,11 +54,11 @@ svcC,SVC configuration,Video,NALu Video
 svcP,SVC priority assignments,Video,NALu Video
 svmC,SVC information configuration,Metadata,NALu Video
 txtC,Text stream configuration,Text,ISO
-udc1,Basic DRC coefficients,Audio,ISO
-udc2,Unified DRC coefficients,Audio,ISO
+udc1,Basic DRC coefficients,Audio,DRC
+udc2,Unified DRC coefficients,Audio,DRC
 udex,Unified DRC configuration extension,Audio,DRC
-udi1,Basic DRC instructions,Audio,ISO
-udi2,Unified DRC instructions,Audio,ISO
+udi1,Basic DRC instructions,Audio,DRC
+udi2,Unified DRC instructions,Audio,DRC
 ueqc,Equalization coefficients,Audio,DRC
 ueqi,Equalization instructions,Audio,DRC
 uriI,URI Information,Metadata,ISO

--- a/CSV/sample-entries-boxes.csv
+++ b/CSV/sample-entries-boxes.csv
@@ -33,7 +33,12 @@ jpgC,JPEG Configuration,Image Item and Image sequences,HEIF
 leqi,Loudness equalization instructions,Audio,DRC
 lhvC,Layered HEVC Configuration,Video,NALu Video
 m4ds,MPEG-4 descriptors,General,NALu Video
+maeI,MPEG-H Audio scene information,Audio,MPEG-H
+maeM,MPEG-H Audio multi-stream signalling,Audio,MPEG-H
 mdcv,mastering display colour volume,Video,ISO
+mhaC,MPEG-H Audio Decoder Configuration,Audio,MPEG-H
+mhaD,MPEG-H Audio dynamic range control and loudness,Audio,MPEG-H
+mhaP,MPEG-H Audio profile and level compatibility set,Audio,MPEG-H
 mvcC,MVC configuration,Video,NALu Video
 mvcP,MVC priority assignment,Video,NALu Video
 mvdC,MVCDConfigurationBox,Video,NALu Video

--- a/CSV/sample-entries.csv
+++ b/CSV/sample-entries.csv
@@ -54,12 +54,12 @@ evs2,Essential Video Coding slice component track that may contain parameter set
 fdp$20,File delivery hints,Hint,ISO,
 g719,ITU-T Recommendation G.719 (2008),Audio,ITU G.719,0xA8
 g726,ITU-T Recommendation G.726 (1990),Audio,SDV,
-hev1,High Efficiency Video Coding,Video,NALu Video,0x23
-hev2,High Efficiency Video Coding,Video,NALu Video,0x23
-hev3,High Efficiency Video Coding,Video,NALu Video,0x23
-hvc1,High Efficiency Video Coding,Video,NALu Video,0x23
-hvc2,High Efficiency Video Coding,Video,NALu Video,0x23
-hvc3,High Efficiency Video Coding,Video,NALu Video,0x23
+hev1,HEVC video with parameter sets in the Sample Entry or samples,Video,NALu Video,0x23
+hev2,HEVC video with constrained extractors and/or aggregators and parameter sets in the Sample Entry or samples,Video,NALu Video,0x23
+hev3,HEVC video with extractors and/or aggregators and parameter sets in the Sample Entry or samples,Video,NALu Video,0x23
+hvc1,HEVC video with parameter sets only in the Sample Entry,Video,NALu Video,0x23
+hvc2,HEVC video with constrained extractors and/or aggregators and parameter sets only in the Sample Entry,Video,NALu Video,0x23
+hvc3,HEVC video with extractors and/or aggregators and parameter sets only in the Sample Entry,Video,NALu Video,0x23
 hvt1,HEVC tile tracks,Video,NALu Video,
 hvt2,HEVC slice segment data track,Video,NALu Video,
 hvt3,HEVC Tile Track with Slice Segment Header Info,Video,NALu Video,

--- a/CSV/sample-entries.csv
+++ b/CSV/sample-entries.csv
@@ -148,3 +148,6 @@ vvc1,Versatile Video Coding with parameter sets only in sample entries,Video,NAL
 vvi1,Versatile Video Coding with parameter sets in sample entries or samples,Video,NALu Video,
 vvs1,Versatile Video Coding (VVC) subpicture track that does not contain a conforming VVC bitstream,Video,NALu Video,
 wvtt,WebVTT data,Text,ISO-Text,
+encu,Encrypted/protected subtitles,Subtitles,ISO,
+encp,Encrypted/protected haptics,Haptics,ISO,
+enc3,Encrypted/protected volumetric visual,Volumetric,ISO,

--- a/CSV/sample-groups.csv
+++ b/CSV/sample-groups.csv
@@ -51,8 +51,8 @@ sync,Sync sample groups,sample group,NALu Video
 tele,Temporal Level,sample group,ISO
 tmsh,Tile mesh sample grouping,sample group,OMAF
 tran,SVC lightweight transcoding,sample group,NALu Video
-trif,HEVC Tile Region,sample group,NALu Video
-tsas,Temporal Sub-Layer,sample group,NALu Video
+trif,Rectangular region group,sample group,NALu Video
+tsas,Temporal Sub-Layer access,sample group,NALu Video
 tscl,Temporal Layer,sample group,NALu Video
 vipr,View priority,sample group,NALu Video
 vopi,VVC operating points information,sample group,NALu Video

--- a/CSV/sample-groups.csv
+++ b/CSV/sample-groups.csv
@@ -16,9 +16,7 @@ dtrt,SVC decode re-timing,sample group,NALu Video
 eob$20,End of bitstream,sample group,NALu Video
 eos$20,End of sequence,sample group,NALu Video
 eqiv,equivalent samples,sample group,HEIF
-iroi,SVC region of interest box,sample group,NALu Video
 lbli,HEVC External base layer,sample group,NALu Video
-ldep,Tier dependency box,sample group,NALu Video
 linf,L-HEVC and VVC layer information,sample group,NALu Video
 minp,VVC mixed NAL unit type pictures,sample group,NALu Video
 mvif,MVC Scalability Information,sample group,NALu Video
@@ -32,7 +30,6 @@ rap$20,Random access point,sample group,ISO
 rash,Rate share,sample group,ISO
 refs,Direct reference samples list,sample group,HEIF
 roll,Pre/Post roll group,sample group,ISO
-rrgn,SVC rect region box,sample group,NALu Video
 rror,Rectangular region order,sample group,NALu Video
 sap$20,Stream access point,sample group,ISO
 seig,Sample Encryption Information,sample group,ISO Common Encryption
@@ -44,13 +41,9 @@ spor,VVC subpicture order,sample group,NALu Video
 stsa,Step-wise Temporal Layer,sample group,NALu Video
 stmi,SampleToMetadataItemEntry,sample group,ISO
 sulm,VVC subpicture layout,sample group,NALu Video
-svdr,SVC dependency range,sample group,NALu Video
-svip,Initial parameter sets box for tiers,sample group,NALu Video
-svpr,Priority range,sample group,NALu Video
 sync,Sync sample groups,sample group,NALu Video
 tele,Temporal Level,sample group,ISO
 tmsh,Tile mesh sample grouping,sample group,OMAF
-tran,SVC lightweight transcoding,sample group,NALu Video
 trif,Rectangular region group,sample group,NALu Video
 tsas,Temporal Sub-Layer access,sample group,NALu Video
 tscl,Temporal Layer,sample group,NALu Video

--- a/CSV/specifications.csv
+++ b/CSV/specifications.csv
@@ -1,105 +1,105 @@
-linkname,specification,description
-3GPP,3GPP,"<a href='http://www.3gpp.org/' target='_blank'>3GPP</a> 26.234 Transparent end-to-end packet switched streaming service (PSS); Protocols and codecs, Annex D;<br><a href='http://www.3gpp.org/' target='_blank'>3GPP</a> 26.244 Transparent end-to-end packet switched streaming service (PSS); 3GPP file format (3GP)"
-3GPP-DASH,3GPP-DASH,"<a href='http://www.3gpp.org/' target='_blank'>3GPP</a> 26.247 Progressive Download and Dynamic Adaptive Streaming over HTTP"
-3GPP-VR,3GPP-VR,"<a href='http://www.3gpp.org/' target='_blank'>3GPP</a> 26.118 3GPP Virtual reality profiles for streaming applications"
-3GPP-TVP,3GPP-TVP,"<a href='http://www.3gpp.org/' target='_blank'>3GPP</a> 26.116 Television (TV) over 3GPP services; Video profiles"
-3GPP2,3GPP2,"<a href='http://www.3gpp2.org/' target='_blank'>3GPP2</a> C.S0050-A, File Formats for Multimedia Services"
-ARRI,ARRI,<a href='http://www.arri.com/'>The ARRI Group</a>
-AV1-ISOBMFF,AV1-ISOBMFF,<a href='https://aomediacodec.github.io/av1-isobmff/'>AV1-ISOBMFF</a>
-AVIF,AVIF,<a href='https://aomediacodec.github.io/av1-avif/'>AVIF</a>
-Avid,Avid,<a href='http://www.avid.com/'>Avid</a>
-apple,Apple,<a href='http://www.apple.com/'>Apple</a> Inc.
-atsc30,ATSC 3.0,<a href='https://www.atsc.org/standards/atsc-3-0-standards/'>ATSC 3.0</a> A337 Application Signaling
-Auro,Auro,<a href='http://www.auro-3d.com/'>Auro Technologies</a>
-Avs2,Avs2,<a href='http://www.gb688.cn/bzgk/gb/newGbInfo?hcno=3AB9CF558421E866CAB2B3115498E7C0'>AVS 2 Specification</a>
-Avs3,Avs3,<a href='http://www.avs.org.cn/AVS3_download/index.asp'>AVS 3 Specification</a>
-bitjazz,BitJazz,<a href='http://www.bitjazz.com/'>BitJazz</a>
-blinkbox,Blinkbox,<a href='http://www.blinkbox.com/'>Blinkbox</a>
-CamMotion,CamMotion,"<a href='https://developers.google.com/streetview/publish/camm-spec' target='_blank'>Camera Motion Metadata Track, Google Inc.</a>, embed various metadata about camera motion including orientation, gyroscope reading, accelerometer reading, positions, etc."
-canon,Canon,<a href='http://www.canon.com/'>Canon</a>
-casio,Casio,<a href='http://world.casio.com/'>Casio</a>
-cineform,CineForm,<a href='http://www.cineform.com/'>Cineform</a>
-convergent,Convergent,<a href='http://www.convergent-design.com/'>Convergent Design</a>
-CMAF,CMAF,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23000-19: Common Media Application Format
-CMAF-ID3,CMAF-ID3,<a href='https://aomediacodec.github.io/id3-emsg/' target='_blank'>Carriage of ID3 Timed Metadata in the Common Media Application Format (CMAF)</a>
-DASH,DASH,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23009-1: Dynamic Adaptive Streaming over HTTP
-dxo,DxO,<a href='http://www.dxo.com/'>DxO</a>
-ISO-CENC,ISO Common Encryption,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23001-7: Common encryption format for ISO base media file format
-DECE10,DECE,Digital Entertainment Content Ecosystem (<a href='http://uvcentral.com/'>DECE</a>) <a href='http://uvcentral.com/'>Common File Format &amp; Media Formats Specification</a>
-DMB-MAF,DMB-MAF,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23000-9 Information technology - Multimedia application format (MPEG-A) - Part 9: Digital Multimedia Broadcasting application format "
-dolby,Dolby,<a href='http://www.dolby.com/'>Dolby</a>
-dolbyvision,Dolby Vision,<a href='https://www.dolby.com/us/en/professional/licensing/apply-license-consumer.aspx'>Dolby Vision</a>
-dra-spec,DRA,"Specification for multichannel digital audio coding technology, SJ/T 11368-2006 (Electronics Industrial Standardization of the People's Republic of China)"
-dts,DTS,<a href='http://dts.com/get-licensed'>DTS</a>
-dtshd,DTS-HD,<a href='http://www.etsi.org/'>ETSI</a> TS 102 114 Coherent Acoustics; Core and Extensions with Additional Profiles (Annex E)
-dtsuhd,DTS-UHD,"<a href='http://www.etsi.org/'>ETSI</a> TS 103 491 DTS-UHD Audio Format; Delivery of Channels, Objects and Ambisonic Sound Fields"
-DVBa121,DVB,DVB <a href='http://www.dvb.org/technology/standards/a121.tm3904r3.ff0020r12.DVB_File_Format_Specification.pdf'>Blue Book A121</a>
-voodoo,Digital Voodoo,<a href='http://www.digitalvoodoo.net/'>Digital Voodoo</a>
-dirac,Dirac,<a href='http://www.diracvideo.org/download/mapping-specs/dirac-mapping-isom-latest.pdf'>Encapsulation</a> of <a href='http://www.bbc.co.uk/rd/projects/dirac/index.shtml'>Dirac</a> in ISO/IEC 14496-12 derivatives
-MLP,Dolby MLP,"MLP (<a href='https://www.dolby.com/us/en/professional/licensing/apply-license-consumer.aspx'>Dolby</a> TrueHD) streams within the ISO Base Media File Format, version 1.0, September 2009"
-DRC,DRC,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23003-4, Dynamic Range Control"
-etsi-ac3,ETSI AC-3,"<a href='http://www.etsi.org/'>ETSI</a> TS 102 366 v1.4.1 - Digital Audio Compression (AC-3, Enhanced AC-3) Standard, Annex F"
-etsi-ac4,ETSI AC-4,"<a href='http://www.etsi.org/'>ETSI</a> TS 103 190 v1.2.1 - Digital Audio Compression (AC-4) Standard, Annex E and TS 103 190-2 v1.1.1 - Digital Audio Compression (AC-4) Standard Part 2: Immersive and personalized audio, Annex E"
-etsi-eac3+,ETSI E-AC-3+JOC,"<a href='http://www.etsi.org/'>ETSI</a> TS 103 420 v1.1.1 - Backwards-compatible object audio carriage using Enhanced AC-3"
-GB-T-20090-9,GB-T-20090-9,<a href='http://www.avs.org.cn/AVS2_download/index.asp'>GB/T 20090.9</a>-2006 Information technology - Advanced coding of audio and video - Part 9: AVS file format
-HEIF,HEIF,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23008-12:2017, Image File Format. Available as a <a href='http://standards.iso.org/ittf/PubliclyAvailableStandards/index.html'>publicly available standard</a> from ISO."
-hum-mon,Hipix,Rich Picture Format from <a href='http://www.hipixpro.com/pdf/What_is_hipix_OCT_2010.pdf'>Human Monitoring</a>
-IEC62592,IEC 62592,"<a href='https://webstore.iec.ch/publication/7232'>IEC</a> TS 62592, Encoding guidelines for portable multimedia CE products using MP4 file format with AVC video codec and AAC audio codec"
-IFE,IFE,"<a href='https://connect.apex.aero/resources/techspecifications'>APEX</a> Specification 0415 Media and Device IFE Ecosystem Specificaton"
-ISMAc,ISMAc,<a href='http://www.isma.tv/' target='_blank'>ISMA</a> 1.0 Encryption and Authentication
-ISMAc2,ISMACryp2,<a href='http://www.isma.tv/' target='_blank'>ISMA</a> 2.0 Encryption and Authentication
-ISO,ISO,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 14496-12:2004 &amp; 15444-12:2004, ISO base media file format. Available as a <a href='http://standards.iso.org/ittf/PubliclyAvailableStandards/index.html'>publicly available standard</a> from ISO."
-ISO-Partial,ISO-Partial,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23001-14:2019, Partial File Format"
-ISOtext,ISO-Text,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 14496-30, Timed text and other visual overlays in ISO base media file format."
-ISO Variants,ISO Variants,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23001-12, Sample Variants."
-ITUG719,ITU G.719,"<a href='http://www.itu.int/ITU-T/'>ITU-T</a> Recommendation G.719 (2008) Amendment 1 (2008): 'New Annex A on storage format definitions for G.719, and new Annex B on a reference floating-point implementation for G.719'"
-itunes,iTunes,General documentation can be found on Apple's <a href='http://developer.apple.com/quicktime/'>developer</a> site
-J2KHEIF,J2KHEIF,"<a href='https://www.iso.org/standard/76647.html'>ISO/IEC 15444-16, Information technology -- JPEG 2000 image coding system -- Part 16: Encapsulation of JPEG 2000 Images into ISO/IEC 23008-12</a>"
-JPEG2000,JPEG2000,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 15444-1, The JPEG 2000 Image Coding System: Core coding system"
-JPX,JPX,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 15444-2, The JPEG 2000 Image Coding System: Extensions"
-JPXR,JPXR,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 29199-2, JPEG XR image coding system: Image coding specification"
-JPXS,JPXS,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC ISO/IEC 21122-3 JPEG XS low-latency lightweight image coding system -- Part 3: Transport and container formats"
-JPM,JPM,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 15444-6, The JPEG 2000 Image Coding System: Compound image file format"
-JPSearch,JPSearch,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 24800-5, JPSearch - Data interchange format between image repositories"
-JXL,JPEG XL,"<a href='https://www.iso.org/standard/80617.html'>ISO/IEC 18181-2, Information technology — JPEG XL Image Coding System — Part 2: File format</a>"
-Leica,Leica,<a href='http://en.leica-camera.com/home/'>Leica</a> Camera AG
-Metrics,Metrics,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23001-10, Carriage of timed metadata metrics of media in ISO base media file format"
-MIAF,MIAF,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23000-22:2019, Multi-Image Application Format."
-MJ2,MJ2,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 15444-3:2003, Motion JPEG 2000"
-MP4V1,MP4v1,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 14496-1, Information technology – Coding of audio-visual objects – Part 1: Systems, (Various versions to 2001), Chapter 13, The MP4 File Format"
-MP4V2,MP4v2,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 14496-14, The MP4 File Format"
-MPEG-4,MPEG-4,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 14496-1, Information technology – Coding of audio-visual objects – Part 1: Systems"
-MPEG21,MPEG-21,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 21000-9, Information technology – MPEG-21 File Format"
-MPEGHAudio,MPEG-H,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23008-3, Information technology – High efficiency coding and media delivery in heterogeneous environments – Part 3: 3D audio"
-MPEG-VSAF,MPEG-VSAF,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23000-10 Video surveillance application format"
-MMT,MMT,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23008-1 MPEG Media Transport
-matrox,Matrox,<a href='http://www.matrox.com/'>Matrox</a>
-AVC,NALu Video,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 14496-15, Carriage of NAL unit structured video in the ISO Base Media File Format"
-nikon,Nikon,<a href='http://www.nikon.com/'>Nikon</a>
-OMADCF,OMA DRM 2.0,"OMA DRM; <a href='http://www.openmobilealliance.org/'>Open Mobile Alliance </a>Digital Rights Management, DRM Content Format 2.0 (OMA-TS-DRM_DCF-V2_0_1-20080226-A)"
-omadcf21,OMA DRM 2.1,"OMA DRM; <a href='http://www.openmobilealliance.org/'>Open Mobile Alliance </a>Digital Rights Management, DRM Content Format 2.1 (OMA-TS-DRM-DCF-V2_1-20070724-C)"
-omadrmxbs,OMA DRM XBS,"OMA DRM; <a href='http://www.openmobilealliance.org/'>Open Mobile Alliance </a>Digital Rights Management, DRM  Extensions for Broadcast Support (OMA-TS-DRM_XBS-V1_0-20070529-C)"
-OMAF,OMAF,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23090-2: Omnidirectional media format
-OMarlin,OMArlin,"The OMArlin Specification, available on request from <a href='http://www.marlin-community.com/join/index.html'>The Marlin Developer Community</a>"
-ONVIF,ONVIF,"<a href='https://www.onvif.org/specs/stream/ONVIF-ExportFileFormat-Spec.pdf' target='_blank'>ONVIF</a>, Export File Format Specification"
-Opus,Opus,<a href='https://www.opus-codec.org/docs/opus_in_isobmff.html'>Encapsulation specification</a> and <a href='https://tools.ietf.org/html/rfc6716'>Codec specification</a>
-piff,PIFF,"The <a href='http://go.microsoft.com/?linkid=9682897'>Protected interoperable file format</a>, Microsoft Corp."
-PNG,PNG,<a href='http://www.libpng.org'>Portable Network Graphics</a>
-panasonic,Panasonic,<a href='http://panasonic.net/avc'>Panasonic</a>
-panasonicvideo,Panasonic Video Intercom,<a href='http://panasonic.net/corporate/segments/psn/'>Panasonic System Networks</a>
-ISO-MAF,ISO-MAF,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23000-3 Information technology - Multimedia application format (MPEG-A) - Part 3: MPEG photo player application format
-QT,QT,"The <a href='http://www.apple.com/quicktime/' target='_blank'>QuickTime</a> File format, Apple Computer Inc."
-RealHD,RealHD,<a href='http://www.realnetworks.com/realmediahd'>RealMedia™ HD</a>
-ross,Ross,<a href='http://www.rossvideo.com/'>Ross Video</a>
-samsung,Samsung,"<a href='http://www.samsung.com/'>Samsung</a> "
-SCTE-215-1-1b,SCTE-215-1-1b,"<a href='https://www.scte.org/download-scteisbe-standards/'>SCTE</a> HEVC Video Constraints for Cable Television Part 1-1 HDR10 Coding"
-SDV,SDV,"<a href='http://www.sdcard.org/'>The SD Card Association</a>: SD Memory Card Specifications, Part 8, VIDEO SPECIFICATIONS"
-SL-HDR,SL-HDR,"<a href='http://www.etsi.org/'>ETSI</a> TS 103 433 - High-Performance Single Layer High Dynamic Range System"
-smptevc1,SMPTE,"<a href='http://www.smpte.org/'>SMPTE</a> RP2025:2007, VC-1 Bitstream Storage in the ISO Base Media File Format"
-Sony,Sony,<a href='http://www.sony.net'>Sony Corporation</a>
-UMG,Universal Music Group,Specification is made available only under license; contact <a href='mailto:uits-%20legal@umusic.com'>Universal Music Group</a>.
-VPxx,VPxx,<a href='https://www.webmproject.org/vp9/mp4/'>Specification</a> of VPxx codecs in ISO BMFF files
-WhatsApp,WhatsApp,<a href='https://www.whatsapp.com/'>WhatsApp Inc.</a>
-Youtube,Youtube,<a href='mailto:ytb-external@google.com'>Google LLC</a>
-id3v2,id3v2,See below
-Deprecated,Deprecated,Deprecated or unused or no longer specified
+specification,description
+3GPP,"<a href='http://www.3gpp.org/' target='_blank'>3GPP</a> 26.234 Transparent end-to-end packet switched streaming service (PSS); Protocols and codecs, Annex D;<br><a href='http://www.3gpp.org/' target='_blank'>3GPP</a> 26.244 Transparent end-to-end packet switched streaming service (PSS); 3GPP file format (3GP)"
+3GPP-DASH,"<a href='http://www.3gpp.org/' target='_blank'>3GPP</a> 26.247 Progressive Download and Dynamic Adaptive Streaming over HTTP"
+3GPP-VR,"<a href='http://www.3gpp.org/' target='_blank'>3GPP</a> 26.118 3GPP Virtual reality profiles for streaming applications"
+3GPP-TVP,"<a href='http://www.3gpp.org/' target='_blank'>3GPP</a> 26.116 Television (TV) over 3GPP services; Video profiles"
+3GPP2,"<a href='http://www.3gpp2.org/' target='_blank'>3GPP2</a> C.S0050-A, File Formats for Multimedia Services"
+ARRI,<a href='http://www.arri.com/'>The ARRI Group</a>
+AV1-ISOBMFF,<a href='https://aomediacodec.github.io/av1-isobmff/'>AV1-ISOBMFF</a>
+AVIF,<a href='https://aomediacodec.github.io/av1-avif/'>AVIF</a>
+Avid,<a href='http://www.avid.com/'>Avid</a>
+Apple,<a href='http://www.apple.com/'>Apple</a> Inc.
+ATSC 3.0,<a href='https://www.atsc.org/standards/atsc-3-0-standards/'>ATSC 3.0</a> A337 Application Signaling
+Auro,<a href='http://www.auro-3d.com/'>Auro Technologies</a>
+Avs2,<a href='http://www.gb688.cn/bzgk/gb/newGbInfo?hcno=3AB9CF558421E866CAB2B3115498E7C0'>AVS 2 Specification</a>
+Avs3,<a href='http://www.avs.org.cn/AVS3_download/index.asp'>AVS 3 Specification</a>
+BitJazz,<a href='http://www.bitjazz.com/'>BitJazz</a>
+Blinkbox,<a href='http://www.blinkbox.com/'>Blinkbox</a>
+CamMotion,"<a href='https://developers.google.com/streetview/publish/camm-spec' target='_blank'>Camera Motion Metadata Track, Google Inc.</a>, embed various metadata about camera motion including orientation, gyroscope reading, accelerometer reading, positions, etc."
+Canon,<a href='http://www.canon.com/'>Canon</a>
+Casio,<a href='http://world.casio.com/'>Casio</a>
+CineForm,<a href='http://www.cineform.com/'>Cineform</a>
+Convergent,<a href='http://www.convergent-design.com/'>Convergent Design</a>
+CMAF,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23000-19: Common Media Application Format
+CMAF-ID3,<a href='https://aomediacodec.github.io/id3-emsg/' target='_blank'>Carriage of ID3 Timed Metadata in the Common Media Application Format (CMAF)</a>
+DASH,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23009-1: Dynamic Adaptive Streaming over HTTP
+DxO,<a href='http://www.dxo.com/'>DxO</a>
+ISO Common Encryption,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23001-7: Common encryption format for ISO base media file format
+DECE,Digital Entertainment Content Ecosystem (<a href='http://uvcentral.com/'>DECE</a>) <a href='http://uvcentral.com/'>Common File Format &amp; Media Formats Specification</a>
+DMB-MAF,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23000-9 Information technology - Multimedia application format (MPEG-A) - Part 9: Digital Multimedia Broadcasting application format "
+Dolby,<a href='http://www.dolby.com/'>Dolby</a>
+Dolby Vision,<a href='https://www.dolby.com/us/en/professional/licensing/apply-license-consumer.aspx'>Dolby Vision</a>
+DRA,"Specification for multichannel digital audio coding technology, SJ/T 11368-2006 (Electronics Industrial Standardization of the People's Republic of China)"
+DTS,<a href='http://dts.com/get-licensed'>DTS</a>
+DTS-HD,<a href='http://www.etsi.org/'>ETSI</a> TS 102 114 Coherent Acoustics; Core and Extensions with Additional Profiles (Annex E)
+DTS-UHD,"<a href='http://www.etsi.org/'>ETSI</a> TS 103 491 DTS-UHD Audio Format; Delivery of Channels, Objects and Ambisonic Sound Fields"
+DVB,DVB <a href='http://www.dvb.org/technology/standards/a121.tm3904r3.ff0020r12.DVB_File_Format_Specification.pdf'>Blue Book A121</a>
+Digital Voodoo,<a href='http://www.digitalvoodoo.net/'>Digital Voodoo</a>
+Dirac,<a href='http://www.diracvideo.org/download/mapping-specs/dirac-mapping-isom-latest.pdf'>Encapsulation</a> of <a href='http://www.bbc.co.uk/rd/projects/dirac/index.shtml'>Dirac</a> in ISO/IEC 14496-12 derivatives
+Dolby MLP,"MLP (<a href='https://www.dolby.com/us/en/professional/licensing/apply-license-consumer.aspx'>Dolby</a> TrueHD) streams within the ISO Base Media File Format, version 1.0, September 2009"
+DRC,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23003-4, Dynamic Range Control"
+ETSI AC-3,"<a href='http://www.etsi.org/'>ETSI</a> TS 102 366 v1.4.1 - Digital Audio Compression (AC-3, Enhanced AC-3) Standard, Annex F"
+ETSI AC-4,"<a href='http://www.etsi.org/'>ETSI</a> TS 103 190 v1.2.1 - Digital Audio Compression (AC-4) Standard, Annex E and TS 103 190-2 v1.1.1 - Digital Audio Compression (AC-4) Standard Part 2: Immersive and personalized audio, Annex E"
+ETSI E-AC-3+JOC,"<a href='http://www.etsi.org/'>ETSI</a> TS 103 420 v1.1.1 - Backwards-compatible object audio carriage using Enhanced AC-3"
+GB-T-20090-9,<a href='http://www.avs.org.cn/AVS2_download/index.asp'>GB/T 20090.9</a>-2006 Information technology - Advanced coding of audio and video - Part 9: AVS file format
+HEIF,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23008-12:2017, Image File Format. Available as a <a href='http://standards.iso.org/ittf/PubliclyAvailableStandards/index.html'>publicly available standard</a> from ISO."
+Hipix,Rich Picture Format from <a href='http://www.hipixpro.com/pdf/What_is_hipix_OCT_2010.pdf'>Human Monitoring</a>
+IEC 62592,"<a href='https://webstore.iec.ch/publication/7232'>IEC</a> TS 62592, Encoding guidelines for portable multimedia CE products using MP4 file format with AVC video codec and AAC audio codec"
+IFE,"<a href='https://connect.apex.aero/resources/techspecifications'>APEX</a> Specification 0415 Media and Device IFE Ecosystem Specificaton"
+ISMAc,<a href='http://www.isma.tv/' target='_blank'>ISMA</a> 1.0 Encryption and Authentication
+ISMACryp2,<a href='http://www.isma.tv/' target='_blank'>ISMA</a> 2.0 Encryption and Authentication
+ISO,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 14496-12:2004 &amp; 15444-12:2004, ISO base media file format. Available as a <a href='http://standards.iso.org/ittf/PubliclyAvailableStandards/index.html'>publicly available standard</a> from ISO."
+ISO-Partial,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23001-14:2019, Partial File Format"
+ISO-Text,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 14496-30, Timed text and other visual overlays in ISO base media file format."
+ISO Variants,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23001-12, Sample Variants."
+ITU G.719,"<a href='http://www.itu.int/ITU-T/'>ITU-T</a> Recommendation G.719 (2008) Amendment 1 (2008): 'New Annex A on storage format definitions for G.719, and new Annex B on a reference floating-point implementation for G.719'"
+iTunes,General documentation can be found on Apple's <a href='http://developer.apple.com/quicktime/'>developer</a> site
+J2KHEIF,"<a href='https://www.iso.org/standard/76647.html'>ISO/IEC 15444-16, Information technology -- JPEG 2000 image coding system -- Part 16: Encapsulation of JPEG 2000 Images into ISO/IEC 23008-12</a>"
+JPEG2000,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 15444-1, The JPEG 2000 Image Coding System: Core coding system"
+JPX,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 15444-2, The JPEG 2000 Image Coding System: Extensions"
+JPXR,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 29199-2, JPEG XR image coding system: Image coding specification"
+JPXS,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC ISO/IEC 21122-3 JPEG XS low-latency lightweight image coding system -- Part 3: Transport and container formats"
+JPM,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 15444-6, The JPEG 2000 Image Coding System: Compound image file format"
+JPSearch,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 24800-5, JPSearch - Data interchange format between image repositories"
+JPEG XL,"<a href='https://www.iso.org/standard/80617.html'>ISO/IEC 18181-2, Information technology — JPEG XL Image Coding System — Part 2: File format</a>"
+Leica,<a href='http://en.leica-camera.com/home/'>Leica</a> Camera AG
+Metrics,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23001-10, Carriage of timed metadata metrics of media in ISO base media file format"
+MIAF,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23000-22:2019, Multi-Image Application Format."
+MJ2,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 15444-3:2003, Motion JPEG 2000"
+MP4v1,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 14496-1, Information technology – Coding of audio-visual objects – Part 1: Systems, (Various versions to 2001), Chapter 13, The MP4 File Format"
+MP4v2,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 14496-14, The MP4 File Format"
+MPEG-4,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 14496-1, Information technology – Coding of audio-visual objects – Part 1: Systems"
+MPEG-21,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 21000-9, Information technology – MPEG-21 File Format"
+MPEG-H,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23008-3, Information technology – High efficiency coding and media delivery in heterogeneous environments – Part 3: 3D audio"
+MPEG-VSAF,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23000-10 Video surveillance application format"
+MMT,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23008-1 MPEG Media Transport
+Matrox,<a href='http://www.matrox.com/'>Matrox</a>
+NALu Video,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 14496-15, Carriage of NAL unit structured video in the ISO Base Media File Format"
+Nikon,<a href='http://www.nikon.com/'>Nikon</a>
+OMA DRM 2.0,"OMA DRM; <a href='http://www.openmobilealliance.org/'>Open Mobile Alliance </a>Digital Rights Management, DRM Content Format 2.0 (OMA-TS-DRM_DCF-V2_0_1-20080226-A)"
+OMA DRM 2.1,"OMA DRM; <a href='http://www.openmobilealliance.org/'>Open Mobile Alliance </a>Digital Rights Management, DRM Content Format 2.1 (OMA-TS-DRM-DCF-V2_1-20070724-C)"
+OMA DRM XBS,"OMA DRM; <a href='http://www.openmobilealliance.org/'>Open Mobile Alliance </a>Digital Rights Management, DRM  Extensions for Broadcast Support (OMA-TS-DRM_XBS-V1_0-20070529-C)"
+OMAF,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23090-2: Omnidirectional media format
+OMArlin,"The OMArlin Specification, available on request from <a href='http://www.marlin-community.com/join/index.html'>The Marlin Developer Community</a>"
+ONVIF,"<a href='https://www.onvif.org/specs/stream/ONVIF-ExportFileFormat-Spec.pdf' target='_blank'>ONVIF</a>, Export File Format Specification"
+Opus,<a href='https://www.opus-codec.org/docs/opus_in_isobmff.html'>Encapsulation specification</a> and <a href='https://tools.ietf.org/html/rfc6716'>Codec specification</a>
+PIFF,"The <a href='http://go.microsoft.com/?linkid=9682897'>Protected interoperable file format</a>, Microsoft Corp."
+PNG,<a href='http://www.libpng.org'>Portable Network Graphics</a>
+Panasonic,<a href='http://panasonic.net/avc'>Panasonic</a>
+Panasonic Video Intercom,<a href='http://panasonic.net/corporate/segments/psn/'>Panasonic System Networks</a>
+ISO-MAF,<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23000-3 Information technology - Multimedia application format (MPEG-A) - Part 3: MPEG photo player application format
+QT,"The <a href='http://www.apple.com/quicktime/' target='_blank'>QuickTime</a> File format, Apple Computer Inc."
+RealHD,<a href='http://www.realnetworks.com/realmediahd'>RealMedia™ HD</a>
+Ross,<a href='http://www.rossvideo.com/'>Ross Video</a>
+Samsung,"<a href='http://www.samsung.com/'>Samsung</a> "
+SCTE-215-1-1b,"<a href='https://www.scte.org/download-scteisbe-standards/'>SCTE</a> HEVC Video Constraints for Cable Television Part 1-1 HDR10 Coding"
+SDV,"<a href='http://www.sdcard.org/'>The SD Card Association</a>: SD Memory Card Specifications, Part 8, VIDEO SPECIFICATIONS"
+SL-HDR,"<a href='http://www.etsi.org/'>ETSI</a> TS 103 433 - High-Performance Single Layer High Dynamic Range System"
+SMPTE,"<a href='http://www.smpte.org/'>SMPTE</a> RP2025:2007, VC-1 Bitstream Storage in the ISO Base Media File Format"
+Sony,<a href='http://www.sony.net'>Sony Corporation</a>
+Universal Music Group,Specification is made available only under license; contact <a href='mailto:uits-%20legal@umusic.com'>Universal Music Group</a>.
+VPxx,<a href='https://www.webmproject.org/vp9/mp4/'>Specification</a> of VPxx codecs in ISO BMFF files
+WhatsApp,<a href='https://www.whatsapp.com/'>WhatsApp Inc.</a>
+Youtube,<a href='mailto:ytb-external@google.com'>Google LLC</a>
+id3v2,See below
+Deprecated,Deprecated or unused or no longer specified

--- a/CSV/track-groups.csv
+++ b/CSV/track-groups.csv
@@ -4,3 +4,4 @@ alte,alternative extraction source track grouping,NALu Video
 cstg,complete subset track grouping,NALu Video
 msrc,multi-source presentation track grouping,ISO
 snut,a group of VVC subpicture tracks where the VCL NAL units of the time-aligned samples have the same NAL unit type,NALu Video
+ster,stereo pair track grouping,ISO

--- a/CSV/track-references.csv
+++ b/CSV/track-references.csv
@@ -1,6 +1,6 @@
 code,description,specification
-adda,Additional audio track,DRC
-adrc,DRC metadata track,DRC
+adda,Additional audio track,ISO
+adrc,DRC metadata track,ISO
 auxl,Auxiliary track reference,ISO
 avcp,AVC parameter set stream link,NALu Video
 cdsc,this track describes the referenced track.,ISO

--- a/CSV/track-references.csv
+++ b/CSV/track-references.csv
@@ -3,7 +3,7 @@ adda,Additional audio track,DRC
 adrc,DRC metadata track,DRC
 auxl,Auxiliary track reference,ISO
 avcp,AVC parameter set stream link,NALu Video
-cdsc,this track describes the referenced track.,MPEG-4
+cdsc,this track describes the referenced track.,ISO
 cdtg,this track describes the referenced tracks and track groups collectively,OMAF
 deps,track containing the depth view,NALu Video
 dpnd,this track has an MPEG-4 dependency on the referenced track,MPEG-4

--- a/CSV/track-references.csv
+++ b/CSV/track-references.csv
@@ -11,7 +11,6 @@ evcr,EVC slice base track,NALu Video
 font,this track uses fonts carried/defined in the referenced track,ISO
 hind,Hint dependency,ISO
 hint,links hint track to original media track,ISO
-iloc,Item data location (item reference),ISO
 ipir,this track contains IPI declarations for the referenced track,MPEG-4
 lyra,Audio layer track dependency,DTS
 mixn,used in indicating combinations that result into mixed network abstraction layer unit types in a coded picture of VVC,NALu Video

--- a/scripts/PRsanitycheck.py
+++ b/scripts/PRsanitycheck.py
@@ -41,10 +41,9 @@ def getCSV4CCs(directory):
                 #Build speclist
                 if fileName == "specifications.csv":
                     for row in csvReader:
-                        linkname = row['linkname']
                         spec = row['specification']
                         desc = row['description']
-                        speclist.append([linkname, spec, desc])
+                        speclist.append([spec, desc])
     return (codesInCSV, speclist)
 
 # 1. Valid, Four Characters Check
@@ -115,7 +114,7 @@ def knownduplicates(filename):
 # Check to make sure all the codes that have Specifications are registered in the specifications.csv file
 def registerspecs(codesInCSV, speclist, specexceptions=[]):
     unregisteredspecs = []
-    allspecs = [spec[1] for spec in speclist]+specexceptions
+    allspecs = [spec[0] for spec in speclist]+specexceptions
     for a in range(len(codesInCSV)):
         if codesInCSV[a][2] not in allspecs:
             unregisteredspecs.append(codesInCSV[a])

--- a/src/app.js
+++ b/src/app.js
@@ -227,7 +227,7 @@ var app = new Vue({
             return e.specification == item.specification;
           }
         );
-        if(spec !== undefined) item.specificationAnchor = spec.linkname;
+        if(spec !== undefined) item.specificationAnchor = spec.specification;
       }
       if ('handler' in item) {
         var handler = und.find(

--- a/src/components/table.vue
+++ b/src/components/table.vue
@@ -7,7 +7,6 @@
   <tbody>
     <tr v-for="item in data">
       <td class="codes" v-if="columns.indexOf('name') !== -1">
-        <a v-bind:name="item.linkname"/>
         {{ item.specification }}
       </td>
       <td v-if="columns.indexOf('code') !== -1" class="code">

--- a/src/components/table.vue
+++ b/src/components/table.vue
@@ -7,6 +7,7 @@
   <tbody>
     <tr v-for="item in data">
       <td class="codes" v-if="columns.indexOf('name') !== -1">
+        <a v-bind:name="item.specification"/>
         {{ item.specification }}
       </td>
       <td v-if="columns.indexOf('code') !== -1" class="code">


### PR DESCRIPTION
while working on the [conformance suite for FileFormat](https://github.com/MPEGGroup/FileFormatConformance) and building up the set of [`standard_features`](https://github.com/MPEGGroup/FileFormatConformance/tree/main/standard_features). I checked the alignment of registered codes between MP4RA, GPAC and the syntax from the actual specs (extracted with a python script). Here is a short summary of findings:

- add MPEG-H audio sample entries
- provide better description for HEVC sample entries
- Add some missing FourCCs from HEIF, ISOBMFF, 
- Re-assign some FourCCs to different spec (because they moved after their registration) includes HEIF, ISO, MP4, DRC, etc.
- Many boxes related to MVC/SVC were registered as sample groups, move them
- Wrongly registered FourCC `mvdd` -> `3dpr`
- Add encrypted sample entries
- Add new handlers for volumetric and haptic tracks

This PR also removes redundant column in specifications.csv