### PR TITLE
Registration of HDR Vivid Config box from CUVA

### DIFF
--- a/CSV/sample-entries-boxes.csv
+++ b/CSV/sample-entries-boxes.csv
@@ -68,3 +68,4 @@ vvnC,VVC Network Abstraction Layer unit configuration,Video,NALu Video
 vvcC,VVC video configuration,Video,NALu Video
 vwid,View identifier,Video,NALu Video
 vlab,WebVTT Source Label,Text,ISO-Text
+cuvv,HDR Vivid Configuration,Video,UWA

--- a/CSV/specifications.csv
+++ b/CSV/specifications.csv
@@ -99,6 +99,7 @@ SL-HDR,"<a href='http://www.etsi.org/'>ETSI</a> TS 103 433 - High-Performance Si
 SMPTE,"<a href='http://www.smpte.org/'>SMPTE</a> RP2025:2007, VC-1 Bitstream Storage in the ISO Base Media File Format"
 Sony,<a href='http://www.sony.net'>Sony Corporation</a>
 Universal Music Group,Specification is made available only under license; contact <a href='mailto:uits-%20legal@umusic.com'>Universal Music Group</a>.
+UWA,"UHD World Association <a href='http://www.theuwa.org/'>UWA</a>, China UHD Video Industry Alliance <a href='http://www.cuva.org.cn'>CUVA</a>: High Dynamic Range Video Technology Part 2-1: Application Guide to System Integration"
 VPxx,<a href='https://www.webmproject.org/vp9/mp4/'>Specification</a> of VPxx codecs in ISO BMFF files
 WhatsApp,<a href='https://www.whatsapp.com/'>WhatsApp Inc.</a>
 Youtube,<a href='mailto:ytb-external@google.com'>Google LLC</a>

--- a/CSV/specifications.csv
+++ b/CSV/specifications.csv
@@ -99,7 +99,7 @@ SL-HDR,"<a href='http://www.etsi.org/'>ETSI</a> TS 103 433 - High-Performance Si
 SMPTE,"<a href='http://www.smpte.org/'>SMPTE</a> RP2025:2007, VC-1 Bitstream Storage in the ISO Base Media File Format"
 Sony,<a href='http://www.sony.net'>Sony Corporation</a>
 Universal Music Group,Specification is made available only under license; contact <a href='mailto:uits-%20legal@umusic.com'>Universal Music Group</a>.
-UWA,"UHD World Association <a href='http://www.theuwa.org/'>UWA</a>, China UHD Video Industry Alliance <a href='http://www.cuva.org.cn'>CUVA</a>: High Dynamic Range Video Technology Part 2-1: Application Guide to System Integration"
+UWA,"UHD World Association <a href='http://www.theuwa.org/'>UWA</a>, China UHD Video Industry Alliance <a href='http://www.cuva.org.cn'>CUVA</a>: CUVA 005.2-2021 - High Dynamic Range Video Technology Part 2-1: Application Guide to System Integration"
 VPxx,<a href='https://www.webmproject.org/vp9/mp4/'>Specification</a> of VPxx codecs in ISO BMFF files
 WhatsApp,<a href='https://www.whatsapp.com/'>WhatsApp Inc.</a>
 Youtube,<a href='mailto:ytb-external@google.com'>Google LLC</a>


### PR DESCRIPTION
UHD World Association  (abbr.  UWA)

High Dynamic Range Video Technology Part 2-1: Application Guide to System Integration Version 1.0
will be redefined as CUVA 005.2-1-2021. and also HDR Vivid related standard documents will be transfered to new organization UWA from CUVA which will cease operation soon once UWA begin operation.