### PR TITLE
Add more boxes from ISO/IEC 18181-2

### DIFF
--- a/CSV/boxes.csv
+++ b/CSV/boxes.csv
@@ -8,6 +8,7 @@ bidx,Box Index,ISO-Partial
 bloc,Base location and purchase location for license acquisition,DECE
 bmdm,Buffer Model Description,JPXS
 bpcc,Bits per component,JPEG2000
+brob,Brotli-compressed box,JPEG XL
 buff,Buffering information,NALu Video
 bxml,binary XML container,ISO
 ccid,OMA DRM Content ID,OMA DRM 2.1
@@ -82,11 +83,14 @@ iprp,Item Properties Box,ISO
 iref,Item reference,ISO
 j2kH,JPEG 2000 header info,J2KHEIF
 j2kP,JPEG 2000 prefix,J2KHEIF
+jbrd,JPEG bitstream reconstruction data,JPEG XL
 jP$20$20,JPEG 2000 Signature,JPEG2000
 jp2c,JPEG 2000 contiguous codestream,JPEG2000
 jp2h,Header,JPEG2000
 jp2i,intellectual property information,JPEG2000
+jumb,JPEG Universal Metadata Box Format (JUMBF),JPEG Systems
 JXL$20,JPEG XL Signature,JPEG XL
+jxll,JPEG XL Level,JPEG XL
 jxlc,JPEG XL Codestream,JPEG XL
 jxli,JPEG XL Frame Index,JPEG XL
 jxlp,JPEG XL Partial Codestream,JPEG XL

--- a/CSV/specifications.csv
+++ b/CSV/specifications.csv
@@ -63,6 +63,7 @@ JPXS,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC ISO/IEC 21122-3 J
 JPM,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 15444-6, The JPEG 2000 Image Coding System: Compound image file format"
 JPSearch,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 24800-5, JPSearch - Data interchange format between image repositories"
 JPEG XL,"<a href='https://www.iso.org/standard/80617.html'>ISO/IEC 18181-2, Information technology — JPEG XL Image Coding System — Part 2: File format</a>"
+JPEG Systems,"<a href='https://jpeg.org/jpegsystems/'>ISO/IEC 19566, Information technologies — JPEG Systems</a>"
 Leica,<a href='http://en.leica-camera.com/home/'>Leica</a> Camera AG
 Metrics,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23001-10, Carriage of timed metadata metrics of media in ISO base media file format"
 MIAF,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23000-22:2019, Multi-Image Application Format."


### PR DESCRIPTION
These boxes are defined in the JPEG XL file format (18181-2).

Likely the `brob` and `jumb` boxes are of interest for other projects as well.