### PR TITLE
Registering FLAC by Xiph.Org Foundation

### DIFF
--- a/CSV/sample-entries-boxes.csv
+++ b/CSV/sample-entries-boxes.csv
@@ -15,6 +15,7 @@ CoLL,Content Light Level Box,Video,VPxx
 dac3,Decoder specific info for AC-3 audio,Audio,ETSI AC-3
 dac4,Decoder specific info for AC-4 audio,Audio,ETSI AC-4
 dec3,Decoder specific info for Enhanced AC-3 audio,Audio,ETSI AC-3
+dfLa,Free Lossless Audio Codec (FLAC) specific data,Audio,FLAC
 dhec,Default HEVC extractor constructor box,Video,NALu Video
 dmix,Downmix instructions,Audio,ISO
 dmlp,Decoder specific info for MLP audio,Audio,Dolby MLP

--- a/CSV/sample-entries.csv
+++ b/CSV/sample-entries.csv
@@ -53,6 +53,7 @@ evs1,Essential Video Coding slice component track without parameter sets,Video,N
 evs2,Essential Video Coding slice component track that may contain parameter sets,Video,NALu Video,
 fdp$20,File delivery hints,Hint,ISO,
 FFV1,An open lossless intra-frame video codec,Video,FF Video Codec,
+fLaC,Free Lossless Audio Codec (FLAC),Audio,FLAC
 g719,ITU-T Recommendation G.719 (2008),Audio,ITU G.719,0xA8
 g726,ITU-T Recommendation G.726 (1990),Audio,SDV,
 hev1,HEVC video with parameter sets in the Sample Entry or samples,Video,NALu Video,0x23

--- a/CSV/specifications.csv
+++ b/CSV/specifications.csv
@@ -41,6 +41,7 @@ DRC,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23003-4, Dynamic R
 ETSI AC-3,"<a href='http://www.etsi.org/'>ETSI</a> TS 102 366 v1.4.1 - Digital Audio Compression (AC-3, Enhanced AC-3) Standard, Annex F"
 ETSI AC-4,"<a href='http://www.etsi.org/'>ETSI</a> TS 103 190 v1.2.1 - Digital Audio Compression (AC-4) Standard, Annex E and TS 103 190-2 v1.1.1 - Digital Audio Compression (AC-4) Standard Part 2: Immersive and personalized audio, Annex E"
 ETSI E-AC-3+JOC,"<a href='http://www.etsi.org/'>ETSI</a> TS 103 420 v1.1.1 - Backwards-compatible object audio carriage using Enhanced AC-3"
+FLAC,"<a href='https://xiph.org/flac/'>FLAC</a> Free Lossless Audio Codec. Encapsulation of FLAC in ISO Base Media File Format"
 GB-T-20090-9,<a href='http://www.avs.org.cn/AVS2_download/index.asp'>GB/T 20090.9</a>-2006 Information technology - Advanced coding of audio and video - Part 9: AVS file format
 FF Video Codec,"<a href='https://datatracker.ietf.org/doc/draft-ietf-cellar-ffv1/' target='_blank'>IETF FFV1</a> Video Coding Format Version 0, 1, and 3"
 HEIF,"<a href='http://www.iso.ch/' target='_blank'>ISO</a>/IEC 23008-12:2017, Image File Format. Available as a <a href='http://standards.iso.org/ittf/PubliclyAvailableStandards/index.html'>publicly available standard</a> from ISO."


### PR DESCRIPTION
The FLAC format is specified at https://xiph.org/flac/format.html but work is underway to further clarify the document and publish it as an IETF RFC. The current draft can be found at https://datatracker.ietf.org/doc/draft-ietf-cellar-flac/ A FLAC-in-MP4 encapsulation specification can be found at https://github.com/xiph/flac/blob/master/doc/isoflac.txt