### PR TITLE
Registering 'seam' by Apple Inc.

### DIFF
--- a/CSV/sample-groups.csv
+++ b/CSV/sample-groups.csv
@@ -32,6 +32,7 @@ refs,Direct reference samples list,sample group,HEIF
 roll,Pre/Post roll group,sample group,ISO
 rror,Rectangular region order,sample group,NALu Video
 sap$20,Stream access point,sample group,ISO
+seam,Identical sequence of samples from an original encoding after separation into overlapping segments stored independently. Group description: 16-byte UUID,sample group,Apple
 seig,Sample Encryption Information,sample group,ISO Common Encryption
 scif,SVC Scalability Information,sample group,NALu Video
 scnm,AVC/SVC/MVC map groups,sample group,NALu Video


### PR DESCRIPTION
'seam' sample group `0x7365616D`

Identical sequence of samples from an original encoding after separation into overlapping segments stored independently. Group description: 16-byte UUID.
