### PR TITLE
Update item-references.csv

### DIFF
--- a/CSV/item-references.csv
+++ b/CSV/item-references.csv
@@ -5,6 +5,7 @@ dimg,Derived image item reference,item ref.,HEIF
 dpnd,Item coding dependency reference,item ref.,HEIF
 exbl,Scalable image item reference, item ref.,HEIF
 fdel,File delivery reference,item ref.,ISO
+font,Font item reference,item ref.,ISO
 grid,Image item grid reference,item ref.,HEIF
 iloc,Item data location,item ref.,ISO
 prem,Pre-Multiplied item,item ref.,MIAF


### PR DESCRIPTION
Add `font`, per ISO/IEC 14496-12:2015 Section 8.11.12.1 "An item reference of type ‘font’ may be used to indicate that an item uses fonts carried/defined in the referenced item."