### PR TITLE
slideshow entity group

### DIFF
--- a/CSV/entity-groups.csv
+++ b/CSV/entity-groups.csv
@@ -1,25 +1,25 @@
 code,description,specification
 acgl,group of VVC subpicture tracks with common properties,NALu Video
-amgl,group of VVC subpicture tracks with different properties,NALu Video
-altr,alternative entity grouping,ISO
-eply,playout entity grouping,V3C-SYS
-eqiv,equivalent entity grouping,HEIF
-opeg,VVC operating points,NALu Video
-oval,Grouping of overlays that are alternatives for switching,OMAF
-ovbg,Grouping of overlays and background visual media that are intended to be presented together,OMAF
-ster,Stereo entity grouping,HEIF
-swpc,Object switch alternatives grouping,V3C-SYS
-swtk,VVC switchable tracks,NALu Video
-vipo,Viewpoint entity grouping,OMAF
-vvcb,VVC bitstream,NALu Video
 aebr,Auto exposure bracketing entity group,HEIF
 afbr,Flash exposure information entity group,HEIF
 albc,Album Collection entity group,HEIF
+amgl,group of VVC subpicture tracks with different properties,NALu Video
+altr,alternative entity grouping,ISO
 brst,Burst image entity group,HEIF
-iaug,Image item with an audio track,HEIF
-tsyn,Time-synchronized capture entity group,HEIF
 dobr,Depth of field bracketing entity group,HEIF
+eply,playout entity grouping,V3C-SYS
+eqiv,equivalent entity grouping,HEIF
 favc,Favorites Collection entity group,HEIF
 fobr,Focus bracketing exposure bracketing,HEIF
+iaug,Image item with an audio track,HEIF
+opeg,VVC operating points,NALu Video
+oval,Grouping of overlays that are alternatives for switching,OMAF
+ovbg,Grouping of overlays and background visual media that are intended to be presented together,OMAF
 pano,Panorama entity group,HEIF
+ster,Stereo entity grouping,HEIF
+swpc,Object switch alternatives grouping,V3C-SYS
+swtk,VVC switchable tracks,NALu Video
+tsyn,Time-synchronized capture entity group,HEIF
+vipo,Viewpoint entity grouping,OMAF
+vvcb,VVC bitstream,NALu Video
 wbbr,White balance bracketing entity group,HEIF

--- a/CSV/entity-groups.csv
+++ b/CSV/entity-groups.csv
@@ -16,6 +16,7 @@ opeg,VVC operating points,NALu Video
 oval,Grouping of overlays that are alternatives for switching,OMAF
 ovbg,Grouping of overlays and background visual media that are intended to be presented together,OMAF
 pano,Panorama entity group,HEIF
+slid,Slideshow entity group,HEIF
 ster,Stereo entity grouping,HEIF
 swpc,Object switch alternatives grouping,V3C-SYS
 swtk,VVC switchable tracks,NALu Video


### PR DESCRIPTION
Adds `slid` entry to entity groups (per ISO/IEC 23008-12:2022 Section 6.8.9.1)

This is provided in two commits - the first just sorts the existing entries (no adds or deletes), and the second adds the `slid` entry. That is just to make it easier to review - they can be squashed on merge.