### PR TITLE
Code point fixes

### DIFF
--- a/data/boxes.csv
+++ b/data/boxes.csv
@@ -24,7 +24,7 @@ coin,Content Information Box,DECE
 colr,specifies the colourspace of the image,JPEG2000
 covi,coverage information,OMAF
 crgn,Reserved,ISO
-crhd,reserved for ClockReferenceStream header,MP4v1
+crhd,reserved for ClockReferenceStream header,MP4v2
 csgp,compact sample to group,ISO
 cslg,composition to decode timeline mapping,ISO
 cstb,corrected wall clock start time,ONVIF
@@ -75,9 +75,9 @@ imda,Identified media data,ISO
 imif,IPMP Information box,ISO
 infe,Item information entry,ISO
 infu,OMA DRM Info URL,OMA DRM 2.0
-iods,Object Descriptor container box,MP4v1
+iods,Object Descriptor container box,MP4v2
 ipco,ItemPropertyContainerBox,ISO
-iphd,reserved for IPMP Stream header,MP4v1
+iphd,reserved for IPMP Stream header,MP4v2
 ipma,ItemPropertyAssociation,ISO
 ipmc,IPMP Control Box,ISO
 ipro,item protection,ISO
@@ -106,7 +106,7 @@ leva,Leval assignment,ISO
 load,Reserved,ISO
 loop,Looping behavior,WhatsApp
 lrcu,OMA DRM Lyrics URI,OMA DRM 2.1
-m7hd,reserved for MPEG7Stream header,MP4v1
+m7hd,reserved for MPEG7Stream header,MP4v2
 matt,Reserved,ISO
 md5i,MD5IntegrityBox,HEIF
 mdat,media data container,ISO
@@ -123,7 +123,7 @@ mfhd,movie fragment header,ISO
 mfra,Movie fragment random access,ISO
 mfro,Movie fragment random access offset,ISO
 minf,media information container,ISO
-mjhd,reserved for MPEG-J Stream header,MP4v1
+mjhd,reserved for MPEG-J Stream header,MP4v2
 mmvi,multimap video,V3C-SYS
 moof,movie fragment,ISO
 moov,container for all the meta-data,ISO
@@ -136,10 +136,10 @@ mvex,movie extends box,ISO
 mvhd,"movie header, overall declarations",ISO
 mvra,Multiview Relation Attribute,NALu Video
 nmhd,"Null media header, overall information (some tracks only)",ISO
-ochd,reserved for ObjectContentInfoStream header,MP4v1
+ochd,reserved for ObjectContentInfoStream header,MP4v2
 odaf,OMA DRM Access Unit Format,OMA DRM 2.0
 odda,OMA DRM Content Object,OMA DRM 2.0
-odhd,reserved for ObjectDescriptorStream header,MP4v1
+odhd,reserved for ObjectDescriptorStream header,MP4v2
 odhe,OMA DRM Discrete Media Headers,OMA DRM 2.0
 odrb,OMA DRM Rights Object,OMA DRM 2.0
 odrm,OMA DRM Container,OMA DRM 2.0
@@ -179,7 +179,7 @@ sbgp,Sample to Group box,ISO
 schi,scheme information box,ISO
 schm,scheme type box,ISO
 sdep,Sample dependency,NALu Video
-sdhd,reserved for SceneDescriptionStream header,MP4v1
+sdhd,reserved for SceneDescriptionStream header,MP4v2
 sdtp,Independent and Disposable Samples Box,ISO
 sdvp,SD Profile Box,SDV
 segr,file delivery session group,ISO

--- a/data/handlers.csv
+++ b/data/handlers.csv
@@ -8,7 +8,7 @@ crsm,ClockReferenceStream,handler,MP4v2
 dmbd,DVB Mandatory Metadata,handler,DVB
 dtva,"TV-Anytime Metadata, according to DVB specifications",handler,DVB
 dvmd,"withdrawn, unused, do not use (was Dolby Vision Metadata)",handler,Deprecated
-fdsm,Font,handler,MPEG-4
+fdsm,Font,handler,ISO
 gesm,General MPEG-4 systems streams (without specific handler),handler,see (1) below
 GRAP,Subtitle Graphics,handler,Sony
 hint,Hint,handler,ISO

--- a/data/handlers.csv
+++ b/data/handlers.csv
@@ -4,7 +4,7 @@ auxv,Auxiliary video,handler,ISO
 avmd,Avid Metadata,handler,Avid
 clcp,Closed Caption,handler,Apple
 cpad,CPCM Auxiliary Metadata,handler,DVB
-crsm,ClockReferenceStream,handler,MPEG-4
+crsm,ClockReferenceStream,handler,MP4v2
 dmbd,DVB Mandatory Metadata,handler,DVB
 dtva,"TV-Anytime Metadata, according to DVB specifications",handler,DVB
 dvmd,"withdrawn, unused, do not use (was Dolby Vision Metadata)",handler,Deprecated
@@ -15,10 +15,10 @@ hint,Hint,handler,ISO
 hpix,Hipix Rich Picture Format,handler,Hipix
 ID32,ID3 version 2 meta-data handler (meta box),handler,id3v2
 ipdc,DVB IPDC ESG Metadata,handler,DVB
-ipsm,IPMP Stream,handler,MPEG-4
-m7sm,MPEG7Stream,handler,MPEG-4
+ipsm,IPMP Stream,handler,MP4v2
+m7sm,MPEG7Stream,handler,MP4v2
 meta,Metadata,handler,ISO
-mjsm,MPEG-J Stream,handler,MPEG-4
+mjsm,MPEG-J Stream,handler,MP4v2
 mp21,MPEG-21 Digital item,handler,MPEG-21
 mp7b,MPEG-7 (binary meta-data),handler,ISO
 mp7t,MPEG-7 (textual meta-data),handler,ISO
@@ -28,12 +28,12 @@ MPEG,QuickTime MPEG track handler,handler,Apple
 musi,QuickTime Music track handler,handler,Apple
 nrtm,Non-Real Time Metadata (XAVC Format),handler,Sony
 null,No handling required (meta-data),handler,ISO
-ocsm,ObjectContentInfoStream,handler,MPEG-4
-odsm,ObjectDescriptorStream,handler,MPEG-4
+ocsm,ObjectContentInfoStream,handler,MP4v2
+odsm,ObjectDescriptorStream,handler,MP4v2
 pict,Image Item and Image sequences,handler,HEIF
 qd3d,QuickTime QuickDraw 3D ttrack handler,handler,Apple
 sbtl,QuickTime Subtitle track handler,handler,Apple
-sdsm,SceneDescriptionStream,handler,MPEG-4
+sdsm,SceneDescriptionStream,handler,MP4v2
 skmm,Key Management Messages,handler,DVB
 smhr,Samsung Video Metadata Handler,handler,Samsung
 soun,Audio,handler,ISO

--- a/data/sample-entries.csv
+++ b/data/sample-entries.csv
@@ -89,9 +89,9 @@ mjp2,Motion JPEG 2000,Video,MJ2,
 mjpg,JPEG image sequences,Video,HEIF,
 mlix,DVB Movie level index track,Metadata,DVB,
 mlpa,MLP Audio,Audio,Dolby MLP,
-mp4a,MPEG-4 Audio,Audio,MP4v1,"0x40, others"
-mp4s,MPEG-4 Systems,(various),MP4v1,various
-mp4v,MPEG-4 Visual,Video,MP4v1,"0x20, others"
+mp4a,MPEG-4 Audio,Audio,MP4v2,"0x40, others"
+mp4s,MPEG-4 Systems,(various),MP4v2,various
+mp4v,MPEG-4 Visual,Video,MP4v2,"0x20, others"
 mvc1,Multiview coding,Video,NALu Video,
 mvc2,Multiview coding,Video,NALu Video,
 mvc3,Multiview coding,Video,NALu Video,

--- a/data/track-references.csv
+++ b/data/track-references.csv
@@ -6,15 +6,15 @@ avcp,AVC parameter set stream link,NALu Video
 cdsc,this track describes the referenced track.,ISO
 cdtg,this track describes the referenced tracks and track groups collectively,OMAF
 deps,track containing the depth view,NALu Video
-dpnd,this track has an MPEG-4 dependency on the referenced track,MPEG-4
+dpnd,this track has an MPEG-4 dependency on the referenced track,MP4v2
 evcr,EVC slice base track,NALu Video
 font,this track uses fonts carried/defined in the referenced track,ISO
 hind,Hint dependency,ISO
 hint,links hint track to original media track,ISO
-ipir,this track contains IPI declarations for the referenced track,MPEG-4
+ipir,this track contains IPI declarations for the referenced track,MP4v2
 lyra,Audio layer track dependency,DTS
 mixn,used in indicating combinations that result into mixed network abstraction layer unit types in a coded picture of VVC,NALu Video
-mpod,this track is an OD track which uses the referenced track as an included elementary stream track,MPEG-4
+mpod,this track is an OD track which uses the referenced track as an included elementary stream track,MP4v2
 oref,track that contains an 'oref' sample group,NALu Video
 recr,resolved by extracting an indicated subset of the referenced VVC track to reconstruct a VVC bitstream,NALu Video
 sabt,HEVC Tile Track,NALu Video
@@ -25,7 +25,7 @@ subp,the referenced VVC subpicture tracks or 'alte' track groups of VVC subpictu
 subt,subtitle or timed text or overlay graphical information,ISO
 swfr,AVC Switch from,NALu Video
 swto,AVC Switch to,NALu Video
-sync,this track uses the referenced track as its synchronization source.,MPEG-4
+sync,this track uses the referenced track as its synchronization source.,MP4v2
 tbas,HEVC Tile track base,NALu Video
 thmb,Thumbnail track reference,ISO
 tmcd,Time code. Usually references a time code track.,Apple


### PR DESCRIPTION
A few items were ascribed to MP4v1 or MPEG-4, which doesn't appear to contain those items.

It looks like this was intended to mean ISO 14496-14 (i.e. `MP4v2` in a spec reference) - they were mostly found in Section 6. The one exception was `fdsm` which is in ISO 14496-12.

